### PR TITLE
Fix Margin Entity

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -26,9 +26,6 @@ import { ZERO } from './lib/helpers';
 let ETHER = BigInt.fromI32(10).pow(18);
 let ONE_MINUTE_SECONDS = BigInt.fromI32(60);
 let SINGLE_INDEX = '0';
-const ETH = 'ETH';
-const BTC = 'BTC';
-const LINK = 'LINK';
 
 export function handleMarketAdded(event: MarketAddedEvent): void {
   let marketEntity = new FuturesMarketEntity(event.params.market.toHex());
@@ -199,32 +196,15 @@ function getTimeID(timestamp: BigInt, num: BigInt): BigInt {
   return timestamp.minus(remainder);
 }
 
-export function handleMarginTransferredBTC(event: MarginTransferredEvent): void {
+export function handleMarginTransferred(event: MarginTransferredEvent): void {
+  let futuresMarketAddress = event.transaction.to as Address;
   const txHash = event.transaction.hash.toHex();
-  let marginTransferEntity = new FuturesMarginTransfer(BTC + '-' + txHash + event.logIndex.toString());
+  let marginTransferEntity = new FuturesMarginTransfer(
+    futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.toString(),
+  );
   marginTransferEntity.timestamp = event.block.timestamp;
   marginTransferEntity.account = event.params.account;
-  marginTransferEntity.market = Bytes.fromUTF8(BTC);
-  marginTransferEntity.size = event.params.marginDelta;
-  marginTransferEntity.save();
-}
-
-export function handleMarginTransferredETH(event: MarginTransferredEvent): void {
-  const txHash = event.transaction.hash.toHex();
-  let marginTransferEntity = new FuturesMarginTransfer(ETH + '-' + txHash + event.logIndex.toString());
-  marginTransferEntity.timestamp = event.block.timestamp;
-  marginTransferEntity.account = event.params.account;
-  marginTransferEntity.market = Bytes.fromUTF8(ETH);
-  marginTransferEntity.size = event.params.marginDelta;
-  marginTransferEntity.save();
-}
-
-export function handleMarginTransferredLINK(event: MarginTransferredEvent): void {
-  const txHash = event.transaction.hash.toHex();
-  let marginTransferEntity = new FuturesMarginTransfer(LINK + '-' + txHash + event.logIndex.toString());
-  marginTransferEntity.timestamp = event.block.timestamp;
-  marginTransferEntity.account = event.params.account;
-  marginTransferEntity.market = Bytes.fromUTF8(LINK);
+  marginTransferEntity.market = futuresMarketAddress;
   marginTransferEntity.size = event.params.marginDelta;
   marginTransferEntity.save();
 }

--- a/subgraphs/futures.js
+++ b/subgraphs/futures.js
@@ -70,7 +70,7 @@ synths.forEach((synth, i) => {
         eventHandlers: [
           {
             event: 'MarginTransferred(indexed address,int256)',
-            handler: 'handleMarginTransferredBTC',
+            handler: 'handleMarginTransferred',
           },
           {
             event: 'PositionModified(indexed uint256,indexed address,uint256,int256,int256,uint256,uint256,uint256)',

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -66,6 +66,14 @@ type FuturesMarginTransfer @entity {
   size: BigInt!
 }
 
+type FundingRateUpdate @entity {
+  id: ID!
+  timestamp: BigInt!
+  market: Bytes!
+  sequenceLength: BigInt!
+  fundingRate: BigInt!
+}
+
 type Candle @entity {
   " synth-period-periodId (periodId is timestamp / period) "
   id: ID!


### PR DESCRIPTION
Margin entity was using a hard-coded asset name (BTC) instead of referencing the market address like other entities.