### PR TITLE
feat: pulled markets from futures-markets.json release artifacts

### DIFF
--- a/subgraphs/futures.js
+++ b/subgraphs/futures.js
@@ -1,6 +1,6 @@
-const { getCurrentNetwork, getContractDeployments } = require('./utils/network');
+const { getCurrentNetwork, getContractDeployments, getFuturesMarkets } = require('./utils/network');
 
-const synths = ['BTC', 'ETH', 'LINK'];
+const synths = getFuturesMarkets(getCurrentNetwork());
 
 const manifest = [];
 

--- a/subgraphs/utils/network.js
+++ b/subgraphs/utils/network.js
@@ -136,6 +136,11 @@ function getContractDeployments(contractName, network = undefined, startBlock = 
   return reverse(addressInfo);
 }
 
+function getFuturesMarkets(network = 'optimism') {
+  const futuresMarkets = getReleaseInfo('futures-markets', network);
+  return futuresMarkets.map(({ marketKey }) => marketKey.substring(1) /* Slicing off the `s` from marketKey */);
+}
+
 const NETWORKS = ['mainnet', 'kovan', 'optimism-kovan', 'optimism'];
 
 module.exports = {
@@ -146,4 +151,5 @@ module.exports = {
   getContractDeployments,
   NETWORKS,
   getCurrentSubgraph,
+  getFuturesMarkets,
 };


### PR DESCRIPTION
Ended up pulling market assets directly from Synthetix's [deployment artifacts](https://github.com/Synthetixio/synthetix/blob/develop/publish/deployed/mainnet-ovm/futures-markets.json) because it looks like we do that similarly here with contract names and was better than introducing a bunch of ethers/provider cruft.

### Proof of Working
Log of `synths` array on op-kovan
<img width="362" alt="image" src="https://user-images.githubusercontent.com/4015977/161837353-fbf46b2a-aafa-43e1-9c94-7e2bd671946c.png">
