### PR TITLE
Profit and Loss

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -140,19 +140,21 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   }
 
   // if the position is closed during this transaction...
+  // set the exit price and close the position
   if (event.params.size.isZero() == true) {
     positionEntity.isOpen = false;
     positionEntity.exitPrice = event.params.lastPrice;
-    const exitPrice = positionEntity.exitPrice;
-    if (exitPrice) {
-      statEntity.pnl = statEntity.pnl.plus(
-        positionEntity.size.times(exitPrice.minus(positionEntity.entryPrice)).div(ETHER),
-      );
-      statEntity.totalVolume = statEntity.totalVolume.plus(
-        positionEntity.size.times(positionEntity.entryPrice).div(ETHER),
-      );
-    }
+    // const exitPrice = positionEntity.exitPrice;
+    // if (exitPrice) {
+    //   statEntity.pnl = statEntity.pnl.plus(
+    //     positionEntity.size.times(exitPrice.minus(positionEntity.entryPrice)).div(ETHER),
+    //   );
+    //   statEntity.totalVolume = statEntity.totalVolume.plus(
+    //     positionEntity.size.times(positionEntity.entryPrice).div(ETHER),
+    //   );
+    // }
   } else {
+    // if the position is not closed...
     // if position changes sides, reset the entry price
     if (
       (positionEntity.size.lt(ZERO) && event.params.size.gt(ZERO)) ||

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -110,13 +110,15 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     positionEntity.entryPrice = event.params.lastPrice;
     positionEntity.lastPrice = event.params.lastPrice;
     positionEntity.margin = event.params.margin;
+    positionEntity.pnl = ZERO;
     positionEntity.feesPaid = ZERO;
     positionEntity.netFunding = ZERO;
     positionEntity.fundingIndex = event.params.fundingIndex;
   }
 
-  // if existing, add accrued funding to position
+  // if there is an existing position...
   if (positionEntity.fundingIndex != event.params.fundingIndex) {
+    // 1. add accrued funding to position
     let pastFundingEntity = FundingRateUpdate.load(
       futuresMarketAddress.toHex() + '-' + positionEntity.fundingIndex.toString(),
     );
@@ -137,6 +139,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
       // set the new index
       positionEntity.fundingIndex = event.params.fundingIndex;
     }
+
+    // 2. calculate the change in pnl for this position
   }
 
   // if the position is closed during this transaction...

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -24,6 +24,7 @@ type FuturesPosition @entity {
   isLiquidated: Boolean!
   size: BigInt!
   margin: BigInt!
+  pnl: BigInt!
   feesPaid: BigInt!
   netFunding: BigInt!
   fundingIndex: BigInt!

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -28,6 +28,7 @@ type FuturesPosition @entity {
   netFunding: BigInt!
   fundingIndex: BigInt!
   entryPrice: BigInt!
+  lastPrice: BigInt!
   exitPrice: BigInt
 }
 

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -27,8 +27,12 @@ type FuturesPosition @entity {
   isLiquidated: Boolean!
   size: BigInt!
   margin: BigInt!
+  pnl: BigInt!
   feesPaid: BigInt!
+  netFunding: BigInt!
+  fundingIndex: BigInt!
   entryPrice: BigInt!
+  lastPrice: BigInt!
   exitPrice: BigInt
 }
 


### PR DESCRIPTION
Updating the pnl calculations for the `FuturesStats` and  `FuturesPosition` entities.

I tried to comment out the logic since it gets a bit complex in certain scenarios. The scenarios we need to handle:

* User closes a position
* User deposits/withdraws margin without modifying their position
* User increases/decreases a position on the same side
* User modifies their position such that it changes side from long to short or short to long