### PR TITLE
Address Bug

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -41,7 +41,7 @@ export function handleMarketRemoved(event: MarketRemovedEvent): void {
 }
 
 export function handlePositionModified(event: PositionModifiedEvent): void {
-  let futuresMarketAddress = event.transaction.to as Address;
+  let futuresMarketAddress = event.address as Address;
   let positionId = futuresMarketAddress.toHex() + '-' + event.params.id.toHex();
   let statId = event.params.account.toHex();
   let marketEntity = FuturesMarketEntity.load(futuresMarketAddress.toHex());


### PR DESCRIPTION
Fixing a bug that occurs when smart contracts submit orders.

We need to get the futures market address from the _event_ rather than the _transaction_. When someone submits an order via a smart contract, `event.transaction.to` will be the smart contract address instead of the futures market address.