### PR TITLE
Bug - Trader 

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -146,7 +146,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
         .div(ETHER);
 
       positionEntity.netFunding = positionEntity.netFunding.plus(fundingAccrued);
-      statEntity.feesPaid = statEntity.feesPaid.plus(fundingAccrued);
+      statEntity.feesPaid = statEntity.feesPaid.minus(fundingAccrued);
 
       // set the new index
       positionEntity.fundingIndex = event.params.fundingIndex;


### PR DESCRIPTION
Found a bug where we are adding funding instead of subtracting. The result is that trader P&L looks different than total position P&L.

An example:
<img width="919" alt="image" src="https://user-images.githubusercontent.com/10401554/163590333-1cc73eed-7e52-49cc-9254-3b7348e42efd.png">

<img width="921" alt="image" src="https://user-images.githubusercontent.com/10401554/163590353-55de425a-e42f-4857-a167-d51b97aaa0d8.png">

To test, I confirmed on a deployment pointing at a development subgraph that these two numbers match exactly.