### PR TITLE
Remove Import

### DIFF
--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,6 +1,5 @@
 import { BigDecimal, BigInt, Bytes, ByteArray, log, Address, dataSource } from '@graphprotocol/graph-ts';
 
-import { LatestRate } from '../../generated/subgraphs/latest-rates/schema';
 import { getContractDeployment } from '../../generated/addresses';
 
 export let ZERO = BigInt.fromI32(0);


### PR DESCRIPTION
Missed an import in the helpers file that pointed at a generated file that existed at the time of testing. I removed all generated files (`generated`+ `build`) and tested a deployment again.