### PR TITLE
adding transaction to subgraph for FuturesMarginTransfer

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -217,6 +217,7 @@ function getTimeID(timestamp: BigInt, num: BigInt): BigInt {
 export function handleMarginTransferred(event: MarginTransferredEvent): void {
   let futuresMarketAddress = event.transaction.to as Address;
   const txHash = event.transaction.hash.toHex();
+  let marketEntity = FuturesMarketEntity.load(futuresMarketAddress.toHex());
   let marginTransferEntity = new FuturesMarginTransfer(
     futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.toString(),
   );
@@ -225,6 +226,11 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
   marginTransferEntity.market = futuresMarketAddress;
   marginTransferEntity.size = event.params.marginDelta;
   marginTransferEntity.txHash = txHash;
+
+  if (marketEntity && marketEntity.asset) {
+    marginTransferEntity.asset = marketEntity.asset;
+  }
+
   marginTransferEntity.save();
 }
 

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -224,6 +224,7 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
   marginTransferEntity.account = event.params.account;
   marginTransferEntity.market = futuresMarketAddress;
   marginTransferEntity.size = event.params.marginDelta;
+  marginTransferEntity.transaction = txHash;
   marginTransferEntity.save();
 }
 

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -224,7 +224,7 @@ export function handleMarginTransferred(event: MarginTransferredEvent): void {
   marginTransferEntity.account = event.params.account;
   marginTransferEntity.market = futuresMarketAddress;
   marginTransferEntity.size = event.params.marginDelta;
-  marginTransferEntity.transaction = txHash;
+  marginTransferEntity.txHash = txHash;
   marginTransferEntity.save();
 }
 

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -61,7 +61,7 @@ type FuturesMarginTransfer @entity {
   account: Bytes!
   market: Bytes!
   size: BigInt!
-  transaction: String!
+  txHash: String!
 }
 
 type FundingRateUpdate @entity {

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -61,6 +61,7 @@ type FuturesMarginTransfer @entity {
   account: Bytes!
   market: Bytes!
   size: BigInt!
+  transaction: String!
 }
 
 type FundingRateUpdate @entity {

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -60,6 +60,7 @@ type FuturesMarginTransfer @entity {
   timestamp: BigInt!
   account: Bytes!
   market: Bytes!
+  asset: Bytes!
   size: BigInt!
   txHash: String!
 }

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -63,6 +63,7 @@ type FuturesMarginTransfer @entity {
   timestamp: BigInt!
   account: Bytes!
   market: Bytes!
+  asset: Bytes!
   size: BigInt!
   txHash: String!
 }

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -64,6 +64,7 @@ type FuturesMarginTransfer @entity {
   account: Bytes!
   market: Bytes!
   size: BigInt!
+  txHash: String!
 }
 
 type FundingRateUpdate @entity {


### PR DESCRIPTION
adding transaction to subgraph for FuturesMarginTransfer. needed for implementation of transfers

https://www.figma.com/file/YWU3PMsnqZaqr1gABgAFJK/UI-Refresh?node-id=2613%3A31391

this will be used on this pr - https://github.com/Kwenta/kwenta/issues/653

the other column im looking at is `Action` which can be derived from the returned `marginDelta` ie `size` attribute based on the notes from the contract:

https://github.com/Synthetixio/synthetix/blob/4d520d726bc013f2642dceb1dad4073fc78f4859/contracts/FuturesMarketBase.sol#L754-L767