### PR TITLE
Add Rates

### DIFF
--- a/src/fragments/latest-rates.ts
+++ b/src/fragments/latest-rates.ts
@@ -95,7 +95,7 @@ function updateCandle(timestamp: BigInt, lastUpdateTimestamp: BigInt, synth: str
           newCandle.close = prevCandle.close;
           newCandle.average = prevCandle.close;
           newCandle.period = period;
-          newCandle.timestamp = timestamp.minus(timestamp.mod(period)); // store the beginning of this period, rather than the timestamp of the first rate update.
+          newCandle.timestamp = newPeriodId.times(period); // store the beginning of this period, rather than the timestamp of the first rate update.
           newCandle.aggregatedPrices = BigInt.fromI32(0);
 
           newCandle.open = prevCandle.close;

--- a/src/fragments/latest-rates.ts
+++ b/src/fragments/latest-rates.ts
@@ -1,0 +1,286 @@
+import {
+  RatesUpdated as RatesUpdatedEvent,
+  AggregatorAdded as AggregatorAddedEvent,
+  InversePriceConfigured,
+  InversePriceFrozen,
+  ExchangeRates,
+} from '../../generated/subgraphs/latest-rates/ExchangeRates_13/ExchangeRates';
+
+import {
+  AggregatorProxy as AggregatorProxyContract,
+  AggregatorConfirmed as AggregatorConfirmedEvent,
+} from '../../generated/subgraphs/latest-rates/ExchangeRates_13/AggregatorProxy';
+
+import { AnswerUpdated as AnswerUpdatedEvent } from '../../generated/subgraphs/latest-rates/templates/Aggregator/Aggregator';
+
+import {
+  AggregatorProxy,
+  SynthAggregatorProxy,
+  InverseAggregatorProxy,
+  Aggregator,
+  SynthAggregator,
+  InverseAggregator,
+} from '../../generated/subgraphs/latest-rates/templates';
+import {
+  LatestRate,
+  InversePricingInfo,
+  RateUpdate,
+  DailyCandle,
+  Candle,
+} from '../../generated/subgraphs/latest-rates/schema';
+
+import { BigDecimal, BigInt, DataSourceContext, dataSource, log, Address, ethereum } from '@graphprotocol/graph-ts';
+
+import { strToBytes, toDecimal, ZERO, ZERO_ADDRESS, CANDLE_PERIODS } from '../lib/helpers';
+
+export function addLatestRate(synth: string, rate: BigInt, aggregator: Address, event: ethereum.Event): void {
+  let decimalRate = toDecimal(rate);
+  addLatestRateFromDecimal(synth, decimalRate, aggregator, event);
+}
+
+export function addLatestRateFromDecimal(
+  synth: string,
+  rate: BigDecimal,
+  aggregator: Address,
+  event: ethereum.Event,
+): void {
+  let prevLatestRate = LatestRate.load(synth);
+  if (prevLatestRate != null && aggregator.notEqual(prevLatestRate.aggregator)) return;
+
+  if (prevLatestRate == null) {
+    prevLatestRate = new LatestRate(synth);
+    prevLatestRate.aggregator = aggregator;
+  }
+
+  prevLatestRate.rate = rate;
+  prevLatestRate.save();
+
+  let rateUpdate = new RateUpdate(event.transaction.hash.toHex() + '-' + synth);
+  rateUpdate.currencyKey = strToBytes(synth);
+  rateUpdate.synth = synth;
+  rateUpdate.rate = rate;
+  rateUpdate.block = event.block.number;
+  rateUpdate.timestamp = event.block.timestamp;
+  rateUpdate.save();
+
+  updateDailyCandle(event.block.timestamp, synth, rate); // DEPRECATED: See updateCandle
+  updateCandle(event.block.timestamp, synth, rate);
+}
+
+function updateCandle(timestamp: BigInt, synth: string, rate: BigDecimal): void {
+  for (let p = 0; p < CANDLE_PERIODS.length; p++) {
+    let period = CANDLE_PERIODS[p];
+    let periodId = timestamp.div(period);
+    let id = synth + '-' + period.toString() + '-' + periodId.toString();
+    let candle = Candle.load(id);
+    if (candle == null) {
+      candle = new Candle(id);
+      candle.synth = synth;
+      candle.open = rate;
+      candle.high = rate;
+      candle.low = rate;
+      candle.close = rate;
+      candle.average = rate;
+      candle.period = period;
+      candle.timestamp = timestamp.minus(timestamp.mod(period)); // store the beginning of this period, rather than the timestamp of the first rate update.
+      candle.aggregatedPrices = BigInt.fromI32(1);
+      candle.save();
+      return;
+    }
+
+    if (candle.low > rate) {
+      candle.low = rate;
+    }
+    if (candle.high < rate) {
+      candle.high = rate;
+    }
+    candle.close = rate;
+    candle.average = calculateAveragePrice(candle.average, rate, candle.aggregatedPrices);
+    candle.aggregatedPrices = candle.aggregatedPrices.plus(BigInt.fromI32(1));
+
+    candle.save();
+  }
+}
+
+function calculateAveragePrice(
+  oldAveragePrice: BigDecimal,
+  newRate: BigDecimal,
+  oldAggregatedPrices: BigInt,
+): BigDecimal {
+  return oldAveragePrice
+    .times(oldAggregatedPrices.toBigDecimal())
+    .plus(newRate)
+    .div(oldAggregatedPrices.plus(BigInt.fromI32(1)).toBigDecimal());
+}
+
+export function addDollar(dollarID: string): void {
+  let dollarRate = new LatestRate(dollarID);
+  dollarRate.rate = new BigDecimal(BigInt.fromI32(1));
+  dollarRate.aggregator = ZERO_ADDRESS;
+  dollarRate.save();
+}
+
+export function addProxyAggregator(currencyKey: string, aggregatorProxyAddress: Address): void {
+  let proxy = AggregatorProxyContract.bind(aggregatorProxyAddress);
+  let underlyingAggregator = proxy.try_aggregator();
+
+  if (!underlyingAggregator.reverted) {
+    let context = new DataSourceContext();
+    context.setString('currencyKey', currencyKey);
+
+    log.info('adding proxy aggregator for synth {}', [currencyKey]);
+
+    if (currencyKey.startsWith('s')) {
+      SynthAggregatorProxy.createWithContext(aggregatorProxyAddress, context);
+    } else if (currencyKey.startsWith('i')) {
+      InverseAggregatorProxy.createWithContext(aggregatorProxyAddress, context);
+    } else {
+      AggregatorProxy.createWithContext(aggregatorProxyAddress, context);
+    }
+
+    addAggregator(currencyKey, underlyingAggregator.value);
+  } else {
+    addAggregator(currencyKey, aggregatorProxyAddress);
+  }
+}
+
+export function addAggregator(currencyKey: string, aggregatorAddress: Address): void {
+  // check current aggregator address, and don't add again if its same
+  let latestRate = LatestRate.load(currencyKey);
+
+  log.info('adding aggregator for synth {}', [currencyKey]);
+
+  if (latestRate != null) {
+    if (aggregatorAddress.equals(latestRate.aggregator)) {
+      return;
+    }
+
+    latestRate.aggregator = aggregatorAddress;
+    latestRate.save();
+  }
+
+  let context = new DataSourceContext();
+  context.setString('currencyKey', currencyKey);
+
+  if (currencyKey.startsWith('s')) {
+    SynthAggregator.createWithContext(aggregatorAddress, context);
+  } else if (currencyKey.startsWith('i')) {
+    InverseAggregator.createWithContext(aggregatorAddress, context);
+  } else {
+    Aggregator.createWithContext(aggregatorAddress, context);
+  }
+}
+
+export function calculateInverseRate(currencyKey: string, beforeRate: BigDecimal): BigDecimal {
+  // since this is inverse pricing, we have to get the latest token information and then apply it to the rate
+  let inversePricingInfo = InversePricingInfo.load(currencyKey);
+
+  if (inversePricingInfo == null) {
+    log.warning('Missing inverse pricing info for asset {}', [currencyKey]);
+    return toDecimal(ZERO);
+  }
+
+  if (inversePricingInfo.frozen) return toDecimal(ZERO);
+
+  let inverseRate = inversePricingInfo.entryPoint.times(new BigDecimal(BigInt.fromI32(2))).minus(beforeRate);
+
+  inverseRate = inversePricingInfo.lowerLimit.lt(inverseRate) ? inverseRate : inversePricingInfo.lowerLimit;
+  inverseRate = inversePricingInfo.upperLimit.gt(inverseRate) ? inverseRate : inversePricingInfo.upperLimit;
+
+  return inverseRate;
+}
+
+export function handleAggregatorAdded(event: AggregatorAddedEvent): void {
+  addProxyAggregator(event.params.currencyKey.toString(), event.params.aggregator);
+}
+
+export function handleAggregatorProxyAddressUpdated(event: AggregatorConfirmedEvent): void {
+  let context = dataSource.context();
+  addAggregator(context.getString('currencyKey'), event.params.latest);
+}
+
+export function handleRatesUpdated(event: RatesUpdatedEvent): void {
+  addDollar('sUSD');
+  addDollar('nUSD');
+
+  let keys = event.params.currencyKeys;
+  let rates = event.params.newRates;
+
+  for (let i = 0; i < keys.length; i++) {
+    if (keys[i].toString() != '') {
+      addLatestRate(keys[i].toString(), rates[i], ZERO_ADDRESS, event);
+    }
+  }
+}
+
+export function handleInverseConfigured(event: InversePriceConfigured): void {
+  let entity = new InversePricingInfo(event.params.currencyKey.toString());
+  entity.entryPoint = toDecimal(event.params.entryPoint);
+  entity.lowerLimit = toDecimal(event.params.lowerLimit);
+  entity.upperLimit = toDecimal(event.params.upperLimit);
+
+  entity.frozen = false;
+
+  entity.save();
+}
+
+export function handleInverseFrozen(event: InversePriceFrozen): void {
+  let entity = new InversePricingInfo(event.params.currencyKey.toString());
+  entity.frozen = true;
+  entity.save();
+
+  let curInverseRate = LatestRate.load(event.params.currencyKey.toString());
+
+  if (!curInverseRate) return;
+
+  addLatestRate(
+    event.params.currencyKey.toString(),
+    event.params.rate,
+    changetype<Address>(curInverseRate.aggregator),
+    event,
+  );
+}
+
+export function handleAggregatorAnswerUpdated(event: AnswerUpdatedEvent): void {
+  let context = dataSource.context();
+  let rate = event.params.current.times(BigInt.fromI32(10).pow(10));
+
+  addDollar('sUSD');
+  addLatestRate(context.getString('currencyKey'), rate, event.address, event);
+}
+
+export function handleInverseAggregatorAnswerUpdated(event: AnswerUpdatedEvent): void {
+  let context = dataSource.context();
+  let rate = event.params.current.times(BigInt.fromI32(10).pow(10));
+
+  let inverseRate = calculateInverseRate(context.getString('currencyKey'), toDecimal(rate));
+
+  if (inverseRate.equals(toDecimal(ZERO))) return;
+
+  addLatestRateFromDecimal(context.getString('currencyKey'), inverseRate as BigDecimal, event.address, event);
+}
+
+// DEPRECATED: See updateCandle
+function updateDailyCandle(timestamp: BigInt, synth: string, rate: BigDecimal): void {
+  let dayID = timestamp.toI32() / 86400;
+  let newCandle = DailyCandle.load(dayID.toString() + '-' + synth);
+  if (newCandle == null) {
+    newCandle = new DailyCandle(dayID.toString() + '-' + synth);
+    newCandle.synth = synth;
+    newCandle.open = rate;
+    newCandle.high = rate;
+    newCandle.low = rate;
+    newCandle.close = rate;
+    newCandle.timestamp = timestamp;
+    newCandle.save();
+    return;
+  }
+  if (newCandle.low > rate) {
+    newCandle.low = rate;
+  }
+  if (newCandle.high < rate) {
+    newCandle.high = rate;
+  }
+  newCandle.close = rate;
+  newCandle.save();
+}

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,6 +1,4 @@
-import { BigDecimal, BigInt, Bytes, ByteArray, log, Address, dataSource } from '@graphprotocol/graph-ts';
-
-import { getContractDeployment } from '../../generated/addresses';
+import { BigDecimal, BigInt, Bytes, Address } from '@graphprotocol/graph-ts';
 
 export let ZERO = BigInt.fromI32(0);
 export let ONE = BigInt.fromI32(1);
@@ -8,18 +6,16 @@ export let ONE = BigInt.fromI32(1);
 export let ZERO_ADDRESS = changetype<Address>(Address.fromHexString('0x0000000000000000000000000000000000000000'));
 export let FEE_ADDRESS = changetype<Address>(Address.fromHexString('0xfeefeefeefeefeefeefeefeefeefeefeefeefeef'));
 
-export let FIFTEEN_MINUTE_SECONDS = BigInt.fromI32(900);
+export let ONE_MINUTE_SECONDS = BigInt.fromI32(60);
 export let DAY_SECONDS = BigInt.fromI32(86400);
-export let YEAR_SECONDS = BigInt.fromI32(31556736);
 
 export let CANDLE_PERIODS: BigInt[] = [
-  YEAR_SECONDS,
-  YEAR_SECONDS.div(BigInt.fromI32(4)),
-  YEAR_SECONDS.div(BigInt.fromI32(12)),
   DAY_SECONDS.times(BigInt.fromI32(7)),
   DAY_SECONDS,
-  FIFTEEN_MINUTE_SECONDS.times(BigInt.fromI32(4)),
-  FIFTEEN_MINUTE_SECONDS,
+  ONE_MINUTE_SECONDS.times(BigInt.fromI32(60)),
+  ONE_MINUTE_SECONDS.times(BigInt.fromI32(15)),
+  ONE_MINUTE_SECONDS.times(BigInt.fromI32(5)),
+  ONE_MINUTE_SECONDS,
 ];
 
 export function toDecimal(value: BigInt, decimals: u32 = 18): BigDecimal {

--- a/subgraphs/fragments/latest-rates.js
+++ b/subgraphs/fragments/latest-rates.js
@@ -1,0 +1,203 @@
+const { getContractDeployments, versions, getCurrentNetwork, getCurrentSubgraph } = require('../utils/network');
+
+const exchangeRatesContractAddresses = getContractDeployments('ExchangeRates');
+
+const exchangeRatesManifests = [];
+
+// the rates updated event changed from bytes4 to bytes32 in the sirius release
+const BYTE32_UPDATE = versions.Sirius;
+
+exchangeRatesContractAddresses.forEach((ca, i) => {
+  let startBlock = ca.startBlock;
+
+  exchangeRatesManifests.push({
+    kind: 'ethereum/contract',
+    name: `ExchangeRates_${i}`,
+    network: getCurrentNetwork(),
+    source: {
+      address: ca.address,
+      startBlock: Math.max(parseInt(process.env.SNX_START_BLOCK || '0'), startBlock),
+      abi: 'ExchangeRates',
+    },
+    mapping: {
+      kind: 'ethereum/events',
+      apiVersion: '0.0.5',
+      language: 'wasm/assemblyscript',
+      file: '../src/fragments/latest-rates.ts',
+      entities: ['LatestRate', 'InversePricingInfo'],
+      abis: [
+        {
+          name: 'ExchangeRates',
+          file: '../abis/ExchangeRates.json',
+        },
+        {
+          name: 'AggregatorProxy',
+          file: '../abis/AggregatorProxy.json',
+        },
+      ],
+      eventHandlers: [
+        {
+          event: 'AggregatorAdded(bytes32,address)',
+          handler: 'handleAggregatorAdded',
+        },
+        {
+          event: 'RatesUpdated(bytes32[],uint256[])',
+          handler: 'handleRatesUpdated',
+        },
+        {
+          event: 'InversePriceConfigured(bytes32,uint256,uint256,uint256)',
+          handler: 'handleInverseConfigured',
+        },
+        {
+          event: 'InversePriceFrozen(bytes32,uint256,uint256,address)',
+          handler: 'handleInverseFrozen',
+        },
+      ],
+    },
+  });
+});
+
+const proxyTemplates = [];
+for (const proxyTemplateName of ['AggregatorProxy', 'SynthAggregatorProxy', 'InverseAggregatorProxy']) {
+  proxyTemplates.push({
+    kind: 'ethereum/contract',
+    name: proxyTemplateName,
+    network: getCurrentNetwork(),
+    source: {
+      abi: 'AggregatorProxy',
+    },
+    mapping: {
+      kind: 'ethereum/events',
+      apiVersion: '0.0.5',
+      language: 'wasm/assemblyscript',
+      file: '../src/fragments/latest-rates.ts',
+      entities: [],
+      abis: [
+        {
+          name: 'AggregatorProxy',
+          file: '../abis/AggregatorProxy.json',
+        },
+      ],
+      eventHandlers: [
+        {
+          event: 'AggregatorConfirmed(indexed address,indexed address)',
+          handler: 'handleAggregatorProxyAddressUpdated',
+        },
+      ],
+    },
+  });
+}
+
+const aggregatorTemplate = {
+  kind: 'ethereum/contract',
+  name: 'Aggregator',
+  network: getCurrentNetwork(),
+  source: {
+    abi: 'Aggregator',
+  },
+  mapping: {
+    kind: 'ethereum/events',
+    apiVersion: '0.0.5',
+    language: 'wasm/assemblyscript',
+    file: '../src/fragments/latest-rates.ts',
+    entities: ['LatestRates'],
+    abis: [
+      {
+        name: 'Aggregator',
+        file: '../abis/Aggregator.json',
+      },
+      {
+        name: 'ExchangeRates',
+        file: '../abis/ExchangeRates.json',
+      },
+      {
+        name: 'AddressResolver',
+        file: '../abis/AddressResolver.json',
+      },
+    ],
+    eventHandlers: [
+      {
+        event: 'AnswerUpdated(indexed int256,indexed uint256,uint256)',
+        handler: 'handleAggregatorAnswerUpdated',
+      },
+    ],
+  },
+};
+
+const synthAggregatorTemplate = {
+  kind: 'ethereum/contract',
+  name: 'SynthAggregator',
+  network: getCurrentNetwork(),
+  source: {
+    abi: 'Aggregator',
+  },
+  mapping: {
+    kind: 'ethereum/events',
+    apiVersion: '0.0.5',
+    language: 'wasm/assemblyscript',
+    file: '../src/fragments/latest-rates.ts',
+    entities: ['LatestRates'],
+    abis: [
+      {
+        name: 'Aggregator',
+        file: '../abis/Aggregator.json',
+      },
+      {
+        name: 'ExchangeRates',
+        file: '../abis/ExchangeRates.json',
+      },
+      {
+        name: 'AddressResolver',
+        file: '../abis/AddressResolver.json',
+      },
+    ],
+    eventHandlers: [
+      {
+        event: 'AnswerUpdated(indexed int256,indexed uint256,uint256)',
+        handler: 'handleAggregatorAnswerUpdated',
+      },
+    ],
+  },
+};
+
+// separate aggregator for inverse synths
+const inverseAggregatorTemplate = {
+  kind: 'ethereum/contract',
+  name: 'InverseAggregator',
+  network: getCurrentNetwork(),
+  source: {
+    abi: 'Aggregator',
+  },
+  mapping: {
+    kind: 'ethereum/events',
+    apiVersion: '0.0.5',
+    language: 'wasm/assemblyscript',
+    file: '../src/fragments/latest-rates.ts',
+    entities: ['LatestRates'],
+    abis: [
+      {
+        name: 'Aggregator',
+        file: '../abis/Aggregator.json',
+      },
+      {
+        name: 'ExchangeRates',
+        file: '../abis/ExchangeRates.json',
+      },
+      {
+        name: 'AddressResolver',
+        file: '../abis/AddressResolver.json',
+      },
+    ],
+    eventHandlers: [
+      {
+        event: 'AnswerUpdated(indexed int256,indexed uint256,uint256)',
+        handler: 'handleInverseAggregatorAnswerUpdated',
+      },
+    ],
+  },
+};
+
+module.exports = {
+  dataSources: exchangeRatesManifests,
+  templates: [...proxyTemplates, aggregatorTemplate, synthAggregatorTemplate, inverseAggregatorTemplate],
+};

--- a/subgraphs/latest-rates.graphql
+++ b/subgraphs/latest-rates.graphql
@@ -1,0 +1,77 @@
+type Candle @entity {
+  " synth-period-periodId (periodId is timestamp / period) "
+  id: ID!
+  " Ticker for synth (e.g. 'sUSD') or 'SNX'"
+  synth: String!
+  open: BigDecimal!
+  high: BigDecimal!
+  low: BigDecimal!
+  close: BigDecimal!
+  average: BigDecimal!
+  timestamp: BigInt!
+  " Duration this candle captures in seconds. Year, quarter, month, week, day, hour, and 15 minutes available. "
+  period: BigInt!
+  " Number of RateUpdates aggregated into this candle, mostly useful for the indexer to calculate averages "
+  aggregatedPrices: BigInt!
+}
+
+type InversePricingInfo @entity {
+  " Name of inverse synth. E.g. iETH "
+  id: ID!
+
+  " whether or not this inverse synth has been frozen "
+  frozen: Boolean!
+
+  " configured upper limit "
+  upperLimit: BigDecimal!
+
+  " configured lower limit "
+  lowerLimit: BigDecimal!
+
+  " matching price point with long synth "
+  entryPoint: BigDecimal!
+}
+
+type LatestRate @entity {
+  " Name of synth. E.g. sUSD "
+  id: ID!
+
+  " Synth USD rate "
+  rate: BigDecimal!
+
+  " Address of the aggregator which produces current result "
+  aggregator: Bytes!
+}
+
+" Latest Rates over time "
+type RateUpdate @entity {
+  " <transaction hash>-<currency key> "
+  id: ID!
+
+  " currencyKey for which this this rate update applies "
+  currencyKey: Bytes!
+
+  " currencyKey expressed as a string "
+  synth: String!
+
+  " the rate recorded at this timestamp "
+  rate: BigDecimal!
+
+  " the block which this rate was recorded "
+  block: BigInt!
+
+  " timestamp of the block in which the rate was recorded "
+  timestamp: BigInt!
+}
+
+" DEPRECATED: See the Candles entity"
+type DailyCandle @entity {
+  " DEPRECATED: See the Candles entity "
+  id: ID!
+  synth: String!
+  open: BigDecimal!
+  high: BigDecimal!
+  low: BigDecimal!
+  close: BigDecimal!
+  timestamp: BigInt!
+}

--- a/subgraphs/latest-rates.graphql
+++ b/subgraphs/latest-rates.graphql
@@ -15,29 +15,15 @@ type Candle @entity {
   aggregatedPrices: BigInt!
 }
 
-type InversePricingInfo @entity {
-  " Name of inverse synth. E.g. iETH "
-  id: ID!
-
-  " whether or not this inverse synth has been frozen "
-  frozen: Boolean!
-
-  " configured upper limit "
-  upperLimit: BigDecimal!
-
-  " configured lower limit "
-  lowerLimit: BigDecimal!
-
-  " matching price point with long synth "
-  entryPoint: BigDecimal!
-}
-
 type LatestRate @entity {
   " Name of synth. E.g. sUSD "
   id: ID!
 
   " Synth USD rate "
   rate: BigDecimal!
+
+  " Timestamp the rate was updated "
+  timestamp: BigInt!
 
   " Address of the aggregator which produces current result "
   aggregator: Bytes!
@@ -61,17 +47,5 @@ type RateUpdate @entity {
   block: BigInt!
 
   " timestamp of the block in which the rate was recorded "
-  timestamp: BigInt!
-}
-
-" DEPRECATED: See the Candles entity"
-type DailyCandle @entity {
-  " DEPRECATED: See the Candles entity "
-  id: ID!
-  synth: String!
-  open: BigDecimal!
-  high: BigDecimal!
-  low: BigDecimal!
-  close: BigDecimal!
   timestamp: BigInt!
 }

--- a/subgraphs/latest-rates.js
+++ b/subgraphs/latest-rates.js
@@ -1,0 +1,12 @@
+const latestRates = require('./fragments/latest-rates');
+
+module.exports = {
+  specVersion: '0.0.2',
+  description: 'Kwenta Rates API',
+  repository: 'https://github.com/Kwenta/kwenta-subgraph',
+  schema: {
+    file: './latest-rates.graphql',
+  },
+  dataSources: latestRates.dataSources,
+  templates: latestRates.templates,
+};


### PR DESCRIPTION
Adding rates back to the main subgraph. This includes all rate update events as well as 1m, 5m, 15m, 1h, and 1d, and 7d candles.

New entities:
- `LatestRate`
- `RateUpdate`
- `Candle`

Test version available [here](https://thegraph.com/hosted-service/subgraph/tburm/optimism-latest-rates)