### PR TITLE
Adjust id futurestrade

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -106,7 +106,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   }
 
   if (event.params.tradeSize.isZero() == false) {
-    let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.transactionIndex.toString());
+    let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
     tradeEntity.timestamp = event.block.timestamp;
     tradeEntity.account = event.params.account;
     tradeEntity.size = event.params.tradeSize;
@@ -399,7 +399,7 @@ export function handleNextPriceOrderRemoved(event: NextPriceOrderRemovedEvent): 
         tradeEntity.orderType = 'NextPrice';
         tradeEntity.save();
       } else {
-        futuresOrderEntity.status = 'Canclled';
+        futuresOrderEntity.status = 'Cancelled';
       }
 
       futuresOrderEntity.save();

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -106,7 +106,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   }
 
   if (event.params.tradeSize.isZero() == false) {
-    let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
+    let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.transactionLogIndex.toString());
     tradeEntity.timestamp = event.block.timestamp;
     tradeEntity.account = event.params.account;
     tradeEntity.size = event.params.tradeSize;

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -114,6 +114,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     tradeEntity.positionId = positionId;
     tradeEntity.price = event.params.lastPrice;
     tradeEntity.feesPaid = event.params.fee;
+    tradeEntity.orderType = 'Market';
 
     if (marketEntity && marketEntity.asset) {
       tradeEntity.asset = marketEntity.asset;

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -392,6 +392,11 @@ export function handleNextPriceOrderRemoved(event: NextPriceOrderRemovedEvent): 
       // TODO: check whether the order was filled/cancelled
       futuresOrderEntity.status = 'Filled';
       futuresOrderEntity.save();
+
+      let tradeEntity = FuturesTrade.load(event.transaction.hash.toHex() + '-' + event.transactionLogIndex.toString());
+      if (tradeEntity) {
+        tradeEntity.orderType = 'NextPrice';
+      }
     }
   }
 }

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -16,7 +16,7 @@ type FuturesTrade @entity {
   positionClosed: Boolean!
   pnl: BigInt!
   feesPaid: BigInt!
-  orderType: FuturesOrder!
+  orderType: FuturesOrderType!
 }
 
 type FuturesPosition @entity {

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -16,6 +16,7 @@ type FuturesTrade @entity {
   positionClosed: Boolean!
   pnl: BigInt!
   feesPaid: BigInt!
+  orderType: FuturesOrder!
 }
 
 type FuturesPosition @entity {
@@ -90,6 +91,7 @@ type FundingRateUpdate @entity {
 enum FuturesOrderType {
   NextPrice
   Limit
+  Market
 }
 
 enum FuturesOrderStatus {

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -19,7 +19,7 @@ type FuturesTrade @entity {
   positionClosed: Boolean!
   pnl: BigInt!
   feesPaid: BigInt!
-  orderType: FuturesOrder!
+  orderType: FuturesOrderType!
 }
 
 type FuturesPosition @entity {

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -14,10 +14,12 @@ type FuturesTrade @entity {
   size: BigInt!
   asset: Bytes!
   price: BigInt!
+  positionId: ID!
   positionSize: BigInt!
   positionClosed: Boolean!
   pnl: BigInt!
   feesPaid: BigInt!
+  orderType: FuturesOrder!
 }
 
 type FuturesPosition @entity {
@@ -92,6 +94,7 @@ type FundingRateUpdate @entity {
 enum FuturesOrderType {
   NextPrice
   Limit
+  Market
 }
 
 enum FuturesOrderStatus {


### PR DESCRIPTION
adjust tradeEntity Id to use `transactionLogIndex` to look up trades after the eventModified position was processed.

add orderType to FuturesTrade and hook into NextPriceOrderRemoved to update FuturesTrade

https://github.com/Kwenta/kwenta/issues/751