### PR TITLE
Exclude rates from main

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -29,6 +29,7 @@ program
   .option('--build-only', 'Skip deploy');
 
 program.action(async () => {
+  const MAIN_SUBGRAPH_EXCLUDE = ['latest-rates'];
   const NETWORK_CHOICES = ['mainnet', 'kovan', 'optimism', 'optimism-kovan'];
   const SUBGRAPH_CHOICES = await fs.readdirSync(path.join(__dirname, '../subgraphs')).reduce((acc, val) => {
     if (val.endsWith('.js') && val !== 'main.js') {
@@ -89,9 +90,12 @@ program.action(async () => {
     // We merge using this strategy to avoid duplicates from the fragments
     let typesArray = [];
     for (let i = 0; i < SUBGRAPH_CHOICES.length; i++) {
-      typesArray.push(
-        (await fs.readFileSync(path.join(__dirname, `../subgraphs/${SUBGRAPH_CHOICES[i]}.graphql`))).toString(),
-      );
+      console.log(MAIN_SUBGRAPH_EXCLUDE);
+      if (!MAIN_SUBGRAPH_EXCLUDE.includes(SUBGRAPH_CHOICES[i])) {
+        typesArray.push(
+          (await fs.readFileSync(path.join(__dirname, `../subgraphs/${SUBGRAPH_CHOICES[i]}.graphql`))).toString(),
+        );
+      }
     }
     const typeDefs = mergeTypeDefs(typesArray);
 

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -113,48 +113,5 @@ type FuturesOrder @entity {
   timestamp: BigInt!
   orderType: FuturesOrderType!
   status: FuturesOrderStatus!
-}
-
-type Candle @entity {
-  " synth-period-periodId (periodId is timestamp / period) "
-  id: ID!
-  " Ticker for synth (e.g. 'sUSD') or 'SNX'"
-  synth: String!
-  open: BigDecimal!
-  high: BigDecimal!
-  low: BigDecimal!
-  close: BigDecimal!
-  average: BigDecimal!
-  timestamp: BigInt!
-  " Duration this candle captures in seconds. Year, quarter, month, week, day, hour, and 15 minutes available. "
-  period: BigInt!
-  " Number of RateUpdates aggregated into this candle, mostly useful for the indexer to calculate averages "
-  aggregatedPrices: BigInt!
-}
-
-type LatestRate @entity {
-  " Name of synth. E.g. sUSD "
-  id: ID!
-  " Synth USD rate "
-  rate: BigDecimal!
-  " Timestamp the rate was updated "
-  timestamp: BigInt!
-  " Address of the aggregator which produces current result "
-  aggregator: Bytes!
-}
-
-" Latest Rates over time "
-type RateUpdate @entity {
-  " <transaction hash>-<currency key> "
-  id: ID!
-  " currencyKey for which this this rate update applies "
-  currencyKey: Bytes!
-  " currencyKey expressed as a string "
-  synth: String!
-  " the rate recorded at this timestamp "
-  rate: BigDecimal!
-  " the block which this rate was recorded "
-  block: BigInt!
-  " timestamp of the block in which the rate was recorded "
-  timestamp: BigInt!
+  keeper: Bytes!
 }

--- a/subgraphs/main.js
+++ b/subgraphs/main.js
@@ -1,8 +1,10 @@
 const fs = require('fs');
 const path = require('path');
 
+const MAIN_SUBGRAPH_EXCLUDE = ['main.js', 'latest-rates.js'];
+
 const includedSubgraphs = fs.readdirSync(path.join(__dirname, '../subgraphs')).reduce((acc, val) => {
-  if (val.endsWith('.js') && val !== 'main.js') {
+  if (val.endsWith('.js') && !MAIN_SUBGRAPH_EXCLUDE.includes(val)) {
     acc.push(val.slice(0, -3));
   }
   return acc;


### PR DESCRIPTION
Remove `latest-rates` from the main subgraph. Motivation is the long syncing time for rates data compared to other subgraph entities.