### PR TITLE
Fix liquidation on deposit withdrawal

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -150,11 +150,11 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
       futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.toString(),
     );
 
-    // this is a hack to get around the fact that the sometimes a withdrawalAll margin transfer event
-    // will trigger a trade entity liquidation to be created.
+    // this check is here to get around the fact that the sometimes a withdrawalAll margin transfer event
+    // will trigger a trade entity liquidation to be created. guarding against this event for now.
     // TODO confirm this is the correct fix for the long term - https://github.com/Kwenta/kwenta/issues/843
     if (marginTransferEntity == null) {
-      // if its not a withdrawal or deposit, it's a liquidation
+      // if its not a withdrawal (or deposit), it's a liquidation
       let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
       tradeEntity.timestamp = event.block.timestamp;
       tradeEntity.account = event.params.account;

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -150,6 +150,9 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
       futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.toString(),
     );
 
+    // this is a hack to get around the fact that the sometimes a withdrawalAll margin transfer event
+    // will trigger a trade entity liquidation to be created.
+    // TODO confirm this is the correct fix for the long term - https://github.com/Kwenta/kwenta/issues/843
     if (marginTransferEntity == null) {
       // if its not a withdrawal or deposit, it's a liquidation
       let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());


### PR DESCRIPTION
fixing withdrawalAll creating a liquidation tradeEntity

https://github.com/Kwenta/kwenta/issues/843

this is the affected area it looks like. When a withdrawalAll is called, it can hit our logic for creating a Liquidation in the PositionModified sometimes (when liquidation criteria is met ie 0 tradeSize, size of 0, margin of 0).

https://github.com/Synthetixio/synthetix/blob/develop/contracts/FuturesMarketBase.sol#L776-L778

to prevent this, I am checking if the marginTransferEntity exists before creating the liquidation, if it does not, we create the `liquidation tradeEntity`

original pr https://github.com/Kwenta/kwenta-subgraph/pull/41