### PR TITLE
adding Liquidation to main graph

### DIFF
--- a/src/futures.ts
+++ b/src/futures.ts
@@ -147,7 +147,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   } else if (event.params.tradeSize.isZero() && event.params.size.isZero() && event.params.margin.isZero()) {
     const txHash = event.transaction.hash.toHex();
     let marginTransferEntity = FuturesMarginTransfer.load(
-      futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.toString(),
+      futuresMarketAddress.toHex() + '-' + txHash + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString(),
     );
 
     // this check is here to get around the fact that the sometimes a withdrawalAll margin transfer event

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -95,6 +95,7 @@ enum FuturesOrderType {
   NextPrice
   Limit
   Market
+  Liquidation
 }
 
 enum FuturesOrderStatus {


### PR DESCRIPTION
fixing the log index the query looks for the margin transfer on

Liquidation is not in the main subgraph `FuturesOrderType` - so its not queryable.

![Screen Shot 2022-05-13 at 2 12 14 PM](https://user-images.githubusercontent.com/5998100/168382728-cfb63460-d36e-4d6c-8c8e-994cdefd567a.png)
![Screen Shot 2022-05-13 at 2 12 19 PM](https://user-images.githubusercontent.com/5998100/168382733-fdc04228-4edf-4833-82aa-3dc643cd661c.png)
