### PR TITLE
Add margin to position entity

### DIFF
--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -33,10 +33,13 @@ type FuturesPosition @entity {
   trades: BigInt!
   totalVolume: BigInt!
   size: BigInt!
+  initialMargin: BigInt!
   margin: BigInt!
   pnl: BigInt!
   feesPaid: BigInt!
   netFunding: BigInt!
+  netTransfers: BigInt!
+  totalDeposits: BigInt!
   fundingIndex: BigInt!
   entryPrice: BigInt!
   avgEntryPrice: BigInt!


### PR DESCRIPTION
Adding to position entity:
- `initialMargin`: The margin value when the position is opened
- `netTransfers`: net of all transfer events, `deposits - withdrawals`
- `totalDeposits`: Total of only deposit margin transfer events

These values will feed into a calculation to create the realized profit and loss percentage:
`pnlPercent = pnl / (initialMargin + totalDeposits)`