### PR TITLE
Fix Liquidation Pnl

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -50,11 +50,11 @@ jobs:
         run: node scripts/deploy.js -t kwenta -s main -n mainnet
         env:
           NETWORK: mainnet
-      - name: Deploy optimistic kovan rates subgraph
-        run: node scripts/deploy.js -t kwenta -s latest-rates -n optimism-kovan
+      - name: Deploy optimistic kovan futures subgraph
+        run: node scripts/deploy.js -t kwenta -s futures -n optimism-kovan
         env:
           NETWORK: optimism-kovan
-      - name: Deploy optimistic mainnet rates subgraph
-        run: node scripts/deploy.js -t kwenta -s latest-rates -n optimism
+      - name: Deploy optimistic mainnet futures subgraph
+        run: node scripts/deploy.js -t kwenta -s futures -n optimism
         env:
           NETWORK: optimism

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -38,6 +38,7 @@ type FuturesPosition @entity {
   pnl: BigInt!
   feesPaid: BigInt!
   netFunding: BigInt!
+  pnlWithFeesPaid: BigInt!
   netTransfers: BigInt!
   totalDeposits: BigInt!
   fundingIndex: BigInt!

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -8,6 +8,7 @@ type FuturesTrade @entity {
   id: ID!
   timestamp: BigInt!
   account: Bytes!
+  margin: BigInt!
   size: BigInt!
   asset: Bytes!
   price: BigInt!


### PR DESCRIPTION
* Correct position pnl in the event of a liquidation
  * Old logic would not result in a 100% loss
  * This logic will always result in a 100% loss net of fees
* Adding `pnlWithFeesPaid` to position entity, since we calculate this on the frontend