### PR TITLE
Add cross margin

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The FuturesPosition entity stores the current state of every Synthetix perpetual
 - These entities store all futures positions, not just those opened on Kwenta.
 - This entity tracks values to the last interaction by the trader (order, margin transfer, trade) but does not include any profit/loss or funding accrued since that interaction.
 - There is unrealized funding and pnl that is not stored on these entities. They are a "snapshot" of the position at the last interaction.
-- Average entry price is updated when a trader _increases_ their position, or is reset to the entry price when the trader changes sides. For example, if a trader modifies a short position into a short position their new `avgEntryPrice` will be the current price at modification.
+- Average entry price is updated when a trader _increases_ their position, or is reset to the entry price when the trader changes sides. For example, if a trader modifies a short position into a long position their new `avgEntryPrice` will be the current price at modification.
 
 ### FuturesTrade
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ The Candle entity stores pricing data for each futures market provided by Chainl
 
 ### FuturesPosition
 
-The FuturesPosition entity stores the current state of every Synthetix perpetual futures position. A new position is created when a position is opened, and is considered closed when the trader modifies the position to have a `size` of zero or gets liquidated.
+The FuturesPosition entity stores the current state of every Synthetix perpetual futures position. A new position is created when a position is opened, and is considered closed when the trader modifies the position to have a `size` of zero or gets liquidated. Cross margin positions are given to the account owner.
 
 - `id` (id) - Unique identifier for this position in the format _market_-_positionId_ where _positionId_ is an incrementing index tracked by the contract.
 - `lastTxHash` (bytes) - Transaction hash of the last interaction with this position.
@@ -95,7 +95,9 @@ The FuturesPosition entity stores the current state of every Synthetix perpetual
 - `timestamp` (integer) - UTC timestamp of the last interaction with this position.
 - `market` (bytes) - Address of the futures market for this position.
 - `asset` (bytes) - A hex encoding of the name of the underlying asset: `sETH` -> `0x...`.
-- `account` (bytes) - Address of the account that opened the position.
+- `account` (bytes) - Address of the account that owns this position. For a cross margin trade, this refers to the account owner.
+- `abstractAccount` (bytes) - Address of the account that send the transaction for this position.
+- `accountType` (bytes) - `isolated_margin` or `cross_margin` depending on the source of the transaction.
 - `isOpen` (boolean) - True if the position is still open.
 - `isLiquidated` (boolean) - True if the position was liquidated.
 - `trades` (integer) - Count of interactions with this position.
@@ -123,11 +125,13 @@ The FuturesPosition entity stores the current state of every Synthetix perpetual
 
 ### FuturesTrade
 
-The FuturesTrade entity stores each interaction with a futures market where a trader either modifies their position size by submitting an order or is liquidated.
+The FuturesTrade entity stores each interaction with a futures market where a trader either modifies their position size by submitting an order or is liquidated. Cross margin trades are given to the account owner.
 
 - `id` (id) - Unique identifier for this trade in the format _txnHash_-_logIndex_.
 - `timestamp` (integer) - UTC timestamp at the time of this trade.
-- `account` (bytes) - Address of the account that made this trade.
+- `account` (bytes) - Address of the account that made this trade. For a cross margin trade, this refers to the account owner.
+- `abstractAccount` (bytes) - Address of the account that send the transaction for this trade.
+- `accountType` (bytes) - `isolated_margin` or `cross_margin` depending on the source of the transaction.
 - `size` (integer) - Size of the trade in native asset.
 - `asset` (bytes) - A hex encoding of the name of the underlying asset: `sETH` -> `0x...`.
 - `price` (integer) - Price of the asset in sUSD at the time of this trade.
@@ -140,9 +144,9 @@ The FuturesTrade entity stores each interaction with a futures market where a tr
 
 ### FuturesStat
 
-The FuturesStat entity stores all-time activity data for each trader.
+The FuturesStat entity stores all-time activity data for each trader. This includes all profits from cross margin trades made by accounts owned by this account.
 
-- `id` (id) - The address of the trader.
+- `id` (id) - The address of a trader.
 - `account` (bytes) - Same as id.
 - `feesPaid` (integer) - Total fees paid in sUSD for all trades.
 - `pnl` (integer) - Total profit/loss in sUSD for all trades.

--- a/abis/MarginAccountFactory.json
+++ b/abis/MarginAccountFactory.json
@@ -1,0 +1,143 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_version",
+        "type": "string"
+      },
+      {
+        "internalType": "address",
+        "name": "_marginAsset",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_addressResolver",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_marginBaseSettings",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "_ops",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "owner",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "NewAccount",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "addressResolver",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [
+      {
+        "internalType": "contract MarginBase",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marginAsset",
+    "outputs": [
+      {
+        "internalType": "contract IERC20",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "marginBaseSettings",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "newAccount",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "ops",
+    "outputs": [
+      {
+        "internalType": "address payable",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "version",
+    "outputs": [
+      {
+        "internalType": "string",
+        "name": "",
+        "type": "string"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  }
+]

--- a/src/crossmargin.ts
+++ b/src/crossmargin.ts
@@ -1,0 +1,14 @@
+import { Address } from '@graphprotocol/graph-ts';
+import { NewAccount as NewAccountEvent } from '../generated/subgraphs/futures/crossmargin_factory/MarginAccountFactory';
+import { CrossMarginAccount } from '../generated/subgraphs/futures/schema';
+
+export function handleNewAccount(event: NewAccountEvent): void {
+  const cmAccountAddress = event.params.account as Address;
+  let crossMarginAccount = CrossMarginAccount.load(cmAccountAddress.toHex());
+
+  if (crossMarginAccount == null) {
+    crossMarginAccount = new CrossMarginAccount(cmAccountAddress.toHex());
+    crossMarginAccount.owner = event.params.owner;
+    crossMarginAccount.save();
+  }
+}

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -11,6 +11,7 @@ import {
   FuturesOneMinStat,
   FundingRateUpdate,
   FuturesOrder,
+  CrossMarginAccount,
 } from '../generated/subgraphs/futures/schema';
 import {
   MarketAdded as MarketAddedEvent,
@@ -44,21 +45,22 @@ export function handleMarketRemoved(event: MarketRemovedEvent): void {
 }
 
 export function handlePositionModified(event: PositionModifiedEvent): void {
+  let sendingAccount = event.params.account;
+  let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
+  const account = crossMarginAccount ? crossMarginAccount.owner : sendingAccount;
+
   let futuresMarketAddress = event.address as Address;
   let positionId = futuresMarketAddress.toHex() + '-' + event.params.id.toHex();
-  let statId = event.params.account.toHex();
   let marketEntity = FuturesMarketEntity.load(futuresMarketAddress.toHex());
   let positionEntity = FuturesPosition.load(positionId);
-  let statEntity = FuturesStat.load(statId);
+  let statEntity = FuturesStat.load(account.toHex());
   let cumulativeEntity = getOrCreateCumulativeEntity();
-  let marginAccountEntity = FuturesMarginAccount.load(
-    event.params.account.toHex() + '-' + futuresMarketAddress.toHex(),
-  );
+  let marginAccountEntity = FuturesMarginAccount.load(sendingAccount.toHex() + '-' + futuresMarketAddress.toHex());
 
   // create new entities
   if (statEntity == null) {
-    statEntity = new FuturesStat(statId);
-    statEntity.account = event.params.account;
+    statEntity = new FuturesStat(account.toHex());
+    statEntity.account = account;
     statEntity.feesPaid = ZERO;
     statEntity.pnl = ZERO;
     statEntity.pnlWithFeesPaid = ZERO;
@@ -74,7 +76,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     if (marketEntity && marketEntity.asset) {
       positionEntity.asset = marketEntity.asset;
     }
-    positionEntity.account = event.params.account;
+    positionEntity.account = account;
+    positionEntity.abstractAccount = sendingAccount;
     positionEntity.isLiquidated = false;
     positionEntity.isOpen = true;
     positionEntity.size = event.params.size;
@@ -98,7 +101,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   if (event.params.tradeSize.isZero() == false) {
     let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
     tradeEntity.timestamp = event.block.timestamp;
-    tradeEntity.account = event.params.account;
+    tradeEntity.account = account;
+    tradeEntity.abstractAccount = account;
     tradeEntity.size = event.params.tradeSize;
     tradeEntity.margin = event.params.margin.plus(event.params.fee);
     tradeEntity.positionSize = event.params.size;
@@ -166,7 +170,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
       // if its not a withdrawal (or deposit), it's a liquidation
       let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
       tradeEntity.timestamp = event.block.timestamp;
-      tradeEntity.account = event.params.account;
+      tradeEntity.account = account;
 
       // create a placeholder for trade size as long/short
       // this will help figure out the trade direction during a liquidation
@@ -286,14 +290,18 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
 }
 
 export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
+  let sendingAccount = event.params.account;
+  let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
+  const account = crossMarginAccount ? crossMarginAccount.owner : sendingAccount;
+
   let futuresMarketAddress = event.address as Address;
   let positionId = futuresMarketAddress.toHex() + '-' + event.params.id.toHex();
   let positionEntity = FuturesPosition.load(positionId);
   let tradeEntity = FuturesTrade.load(
     event.transaction.hash.toHex() + '-' + event.logIndex.minus(BigInt.fromI32(1)).toString(),
   );
-  let statId = event.params.account.toHex();
-  let statEntity = FuturesStat.load(statId);
+
+  let statEntity = FuturesStat.load(account.toHex());
   if (statEntity && statEntity.liquidations) {
     statEntity.liquidations = statEntity.liquidations.plus(BigInt.fromI32(1));
     statEntity.save();
@@ -423,13 +431,12 @@ export function handleFundingRecomputed(event: FundingRecomputedEvent): void {
 export function handleNextPriceOrderSubmitted(event: NextPriceOrderSubmittedEvent): void {
   if (event.params.trackingCode.toString() == 'KWENTA') {
     let futuresMarketAddress = event.address as Address;
+    let sendingAccount = event.params.account;
+    let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
+    const account = crossMarginAccount ? crossMarginAccount.owner : sendingAccount;
 
     const futuresOrderEntityId =
-      futuresMarketAddress.toHex() +
-      '-' +
-      event.params.account.toHexString() +
-      '-' +
-      event.params.targetRoundId.toString();
+      futuresMarketAddress.toHex() + '-' + sendingAccount.toHexString() + '-' + event.params.targetRoundId.toString();
 
     let futuresOrderEntity = FuturesOrder.load(futuresOrderEntityId);
 
@@ -447,7 +454,7 @@ export function handleNextPriceOrderSubmitted(event: NextPriceOrderSubmittedEven
     }
 
     futuresOrderEntity.market = futuresMarketAddress;
-    futuresOrderEntity.account = event.params.account;
+    futuresOrderEntity.account = account;
     futuresOrderEntity.size = event.params.sizeDelta;
     futuresOrderEntity.targetRoundId = event.params.targetRoundId;
     futuresOrderEntity.timestamp = event.block.timestamp;
@@ -458,16 +465,15 @@ export function handleNextPriceOrderSubmitted(event: NextPriceOrderSubmittedEven
 
 export function handleNextPriceOrderRemoved(event: NextPriceOrderRemovedEvent): void {
   if (event.params.trackingCode.toString() == 'KWENTA') {
-    const statId = event.params.account.toHex();
-    let statEntity = FuturesStat.load(statId);
+    let sendingAccount = event.params.account;
+    let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
+    const account = crossMarginAccount ? crossMarginAccount.owner : sendingAccount;
+
+    let statEntity = FuturesStat.load(account.toHex());
 
     let futuresMarketAddress = event.address as Address;
     let futuresOrderEntity = FuturesOrder.load(
-      futuresMarketAddress.toHex() +
-        '-' +
-        event.params.account.toHexString() +
-        '-' +
-        event.params.targetRoundId.toString(),
+      futuresMarketAddress.toHex() + '-' + sendingAccount.toHexString() + '-' + event.params.targetRoundId.toString(),
     );
 
     if (futuresOrderEntity) {

--- a/src/futures.ts
+++ b/src/futures.ts
@@ -48,6 +48,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
   let sendingAccount = event.params.account;
   let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
   const account = crossMarginAccount ? crossMarginAccount.owner : sendingAccount;
+  const accountType = crossMarginAccount ? 'cross_margin' : 'isolated_margin';
 
   let futuresMarketAddress = event.address as Address;
   let positionId = futuresMarketAddress.toHex() + '-' + event.params.id.toHex();
@@ -78,6 +79,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     }
     positionEntity.account = account;
     positionEntity.abstractAccount = sendingAccount;
+    positionEntity.accountType = accountType;
     positionEntity.isLiquidated = false;
     positionEntity.isOpen = true;
     positionEntity.size = event.params.size;
@@ -102,7 +104,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
     tradeEntity.timestamp = event.block.timestamp;
     tradeEntity.account = account;
-    tradeEntity.abstractAccount = account;
+    tradeEntity.abstractAccount = sendingAccount;
+    tradeEntity.accountType = accountType;
     tradeEntity.size = event.params.tradeSize;
     tradeEntity.margin = event.params.margin.plus(event.params.fee);
     tradeEntity.positionSize = event.params.size;
@@ -171,6 +174,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
       let tradeEntity = new FuturesTrade(event.transaction.hash.toHex() + '-' + event.logIndex.toString());
       tradeEntity.timestamp = event.block.timestamp;
       tradeEntity.account = account;
+      tradeEntity.abstractAccount = sendingAccount;
+      tradeEntity.accountType = accountType;
 
       // create a placeholder for trade size as long/short
       // this will help figure out the trade direction during a liquidation

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -9,6 +9,7 @@ type FuturesTrade @entity {
   timestamp: BigInt!
   account: Bytes!
   abstractAccount: Bytes!
+  accountType: FuturesAccountType!
   margin: BigInt!
   size: BigInt!
   asset: Bytes!
@@ -31,6 +32,7 @@ type FuturesPosition @entity {
   asset: Bytes!
   account: Bytes!
   abstractAccount: Bytes!
+  accountType: FuturesAccountType!
   isOpen: Boolean!
   isLiquidated: Boolean!
   trades: BigInt!
@@ -117,6 +119,11 @@ enum FuturesOrderStatus {
   Pending
   Filled
   Cancelled
+}
+
+enum FuturesAccountType {
+  isolated_margin
+  cross_margin
 }
 
 type FuturesOrder @entity {

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -8,6 +8,7 @@ type FuturesTrade @entity {
   id: ID!
   timestamp: BigInt!
   account: Bytes!
+  abstractAccount: Bytes!
   margin: BigInt!
   size: BigInt!
   asset: Bytes!
@@ -29,6 +30,7 @@ type FuturesPosition @entity {
   market: Bytes!
   asset: Bytes!
   account: Bytes!
+  abstractAccount: Bytes!
   isOpen: Boolean!
   isLiquidated: Boolean!
   trades: BigInt!
@@ -128,4 +130,9 @@ type FuturesOrder @entity {
   orderType: FuturesOrderType!
   status: FuturesOrderStatus!
   keeper: Bytes!
+}
+
+type CrossMarginAccount @entity {
+  id: ID!
+  owner: Bytes!
 }

--- a/subgraphs/futures.js
+++ b/subgraphs/futures.js
@@ -4,6 +4,7 @@ const synths = getFuturesMarkets(getCurrentNetwork());
 
 const manifest = [];
 
+// futures market manager
 getContractDeployments('FuturesMarketManager').forEach((a, i) => {
   manifest.push({
     kind: 'ethereum/contract',
@@ -44,6 +45,7 @@ getContractDeployments('FuturesMarketManager').forEach((a, i) => {
   });
 });
 
+// futures markets
 synths.forEach((synth, i) => {
   getContractDeployments(`FuturesMarket${synth}`).forEach((a, i) => {
     manifest.push({
@@ -96,6 +98,45 @@ synths.forEach((synth, i) => {
       },
     });
   });
+});
+
+// crossmargin
+// addresses
+TESTNET_CROSSMARGIN_ADDRESS = '0xB2e8d9832C8a22C6fB6D2c92c7E2a69d654749CB';
+MAINNET_CROSSMARGIN_ADDRESS = '';
+
+// set up
+const crossMarginAddress =
+  getCurrentNetwork() === 'optimism-main' ? MAINNET_CROSSMARGIN_ADDRESS : TESTNET_CROSSMARGIN_ADDRESS;
+
+manifest.push({
+  kind: 'ethereum/contract',
+  name: `crossmargin_factory`,
+  network: getCurrentNetwork(),
+  source: {
+    address: crossMarginAddress,
+    startBlock: 0,
+    abi: 'MarginAccountFactory',
+  },
+  mapping: {
+    kind: 'ethereum/events',
+    apiVersion: '0.0.5',
+    language: 'wasm/assemblyscript',
+    file: '../src/crossmargin.ts',
+    entities: ['MarginAccountFactory'],
+    abis: [
+      {
+        name: 'MarginAccountFactory',
+        file: '../abis/MarginAccountFactory.json',
+      },
+    ],
+    eventHandlers: [
+      {
+        event: 'NewAccount(indexed address,address)',
+        handler: 'handleNewAccount',
+      },
+    ],
+  },
 });
 
 module.exports = {

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -173,6 +173,8 @@ type FuturesTrade @entity {
   id: ID!
   timestamp: BigInt!
   account: Bytes!
+  abstractAccount: Bytes!
+  margin: BigInt!
   size: BigInt!
   asset: Bytes!
   price: BigInt!
@@ -193,6 +195,7 @@ type FuturesPosition @entity {
   market: Bytes!
   asset: Bytes!
   account: Bytes!
+  abstractAccount: Bytes!
   isOpen: Boolean!
   isLiquidated: Boolean!
   trades: BigInt!
@@ -203,6 +206,7 @@ type FuturesPosition @entity {
   pnl: BigInt!
   feesPaid: BigInt!
   netFunding: BigInt!
+  pnlWithFeesPaid: BigInt!
   netTransfers: BigInt!
   totalDeposits: BigInt!
   fundingIndex: BigInt!
@@ -291,4 +295,9 @@ type FuturesOrder @entity {
   orderType: FuturesOrderType!
   status: FuturesOrderStatus!
   keeper: Bytes!
+}
+
+type CrossMarginAccount @entity {
+  id: ID!
+  owner: Bytes!
 }


### PR DESCRIPTION
Add support for cross margin accounts to the futures subgraph. 

Adds or changes the following values:
* `accountType`: either `isolated_margin` or `cross_margin` depending on the source of the transaction
* `account`: Account refers to the "parent" account of the transaction. In a cross margin trade, this is the account that created the cross margin account.
* `abstractAccount`: This is the account that created the transaction. In a cross margin trade, this is the cross margin account address.