### PR TITLE
Hourly market entity

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ The FuturesCumulativeStat entity stores all-time activity data for each perp mar
 - `totalVolume` (integer) - Total trading volume of the trader in sUSD.
 - `averageTradeSize` (integer) - Total volume divided by the number of trades.
 
+### FuturesHourlyStat
+
+The FuturesHourlyStat entity stores hourly activity data for each perp market.
+
+- `id` (id) - The address of the market and the unix timestamp at the beginning of the hour, `-` separated.
+- `timestamp` (integer) - Unix timestamp in seconds at the start of this hour.
+- `asset` (bytes) - A hex encoding of the name of the underlying asset: `sETH` -> `0x...`.
+- `trades` (integer) - Count of trades this hour.
+- `volume` (integer) - Total trading volume on this market in sUSD.
+
 ### FuturesMarginTransfer
 
 The FuturesMarginTransfer entity stores each deposit or withdrawal of margin between a trader and a futures market.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@graphprotocol/graph-ts": "0.25.0",
         "@graphql-tools/merge": "^8.2.1",
         "chalk": "4.1.2",
+        "codegen-graph-ts": "^0.1.4",
         "commander": "8.2.0",
         "eslint-config-prettier": "^8.3.0",
         "mustache": "4.2.0",
@@ -1231,6 +1232,16 @@
         "antlr4ts": "^0.5.0-alpha.4"
       }
     },
+    "node_modules/@synthetixio/wei": {
+      "version": "2.74.4",
+      "resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.4.tgz",
+      "integrity": "sha512-mecIlBsNv9fRmr4ZdmApnlyku1ZRLTx6DAKx96zfUxRaBq7O/q9eETAXdWwq687xdh40SaVPOu3vpS0Kt7+P2g==",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "big.js": "^6.1.1"
+      }
+    },
     "node_modules/@types/abstract-leveldown": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
@@ -1975,6 +1986,18 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "node_modules/big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ==",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bigjs"
+      }
+    },
     "node_modules/bignumber.js": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
@@ -2551,6 +2574,30 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/codegen-graph-ts": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/codegen-graph-ts/-/codegen-graph-ts-0.1.4.tgz",
+      "integrity": "sha512-/O5B9CTzIhCLp+gj3njgtvkFq1CqMMWIX9W3aeg3U41ZwZ8vjkPYKbmxCoHspmMHYgWOgmyK9R/kPrMU/MKLRA==",
+      "dependencies": {
+        "@synthetixio/wei": "^2.47.0-ovm.5",
+        "axios": "^0.24.0",
+        "commander": "^8.1.0",
+        "graphql": "^15.5.1",
+        "graphql-request": "^3.5.0",
+        "lodash": "^4.17.21"
+      },
+      "bin": {
+        "codegen-graph-ts": "build/src/gen/index.js"
+      }
+    },
+    "node_modules/codegen-graph-ts/node_modules/axios": {
+      "version": "0.24.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+      "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+      "dependencies": {
+        "follow-redirects": "^1.14.4"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -2722,6 +2769,33 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "node_modules/cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "dependencies": {
+        "node-fetch": "2.6.7"
+      }
+    },
+    "node_modules/cross-fetch/node_modules/node-fetch": {
+      "version": "2.6.7",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
       }
     },
     "node_modules/cross-spawn": {
@@ -4107,6 +4181,17 @@
         "node": ">=0.6.0"
       }
     },
+    "node_modules/extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ==",
+      "engines": {
+        "node": "^10.17.0 || ^12.0.0 || >= 13.7.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jaydenseric"
+      }
+    },
     "node_modules/extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -4216,9 +4301,9 @@
       "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA==",
       "funding": [
         {
           "type": "individual",
@@ -4558,11 +4643,37 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "node_modules/graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw==",
       "engines": {
         "node": ">= 10.x"
+      }
+    },
+    "node_modules/graphql-request": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+      "dependencies": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "14 - 16"
+      }
+    },
+    "node_modules/graphql-request/node_modules/form-data": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+      "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/har-schema": {
@@ -9916,6 +10027,11 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "node_modules/true-case-path": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
@@ -10245,6 +10361,20 @@
       "version": "4.11.8",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -11408,6 +11538,16 @@
         "antlr4ts": "^0.5.0-alpha.4"
       }
     },
+    "@synthetixio/wei": {
+      "version": "2.74.4",
+      "resolved": "https://registry.npmjs.org/@synthetixio/wei/-/wei-2.74.4.tgz",
+      "integrity": "sha512-mecIlBsNv9fRmr4ZdmApnlyku1ZRLTx6DAKx96zfUxRaBq7O/q9eETAXdWwq687xdh40SaVPOu3vpS0Kt7+P2g==",
+      "requires": {
+        "@ethersproject/bignumber": "^5.6.2",
+        "@ethersproject/bytes": "^5.6.1",
+        "big.js": "^6.1.1"
+      }
+    },
     "@types/abstract-leveldown": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
@@ -11945,6 +12085,11 @@
         "tweetnacl": "^0.14.3"
       }
     },
+    "big.js": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/big.js/-/big.js-6.2.1.tgz",
+      "integrity": "sha512-bCtHMwL9LeDIozFn+oNhhFoq+yQ3BNdnsLSASUxLciOb1vgvpHsIO1dsENiGMgbb4SkP5TrzWzRiLddn8ahVOQ=="
+    },
     "bignumber.js": {
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.0.tgz",
@@ -12422,6 +12567,29 @@
       "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
       "integrity": "sha1-2jCcwmPfFZlMaIypAheco8fNfH4="
     },
+    "codegen-graph-ts": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/codegen-graph-ts/-/codegen-graph-ts-0.1.4.tgz",
+      "integrity": "sha512-/O5B9CTzIhCLp+gj3njgtvkFq1CqMMWIX9W3aeg3U41ZwZ8vjkPYKbmxCoHspmMHYgWOgmyK9R/kPrMU/MKLRA==",
+      "requires": {
+        "@synthetixio/wei": "^2.47.0-ovm.5",
+        "axios": "^0.24.0",
+        "commander": "^8.1.0",
+        "graphql": "^15.5.1",
+        "graphql-request": "^3.5.0",
+        "lodash": "^4.17.21"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.24.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.24.0.tgz",
+          "integrity": "sha512-Q6cWsys88HoPgAaFAVUb0WpPk0O8iTeisR9IMqy9G8AbO4NlpVknrnQS03zzF9PGAWgO3cgletO3VjV/P7VztA==",
+          "requires": {
+            "follow-redirects": "^1.14.4"
+          }
+        }
+      }
+    },
     "color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -12563,6 +12731,24 @@
         "ripemd160": "^2.0.0",
         "safe-buffer": "^5.0.1",
         "sha.js": "^2.4.8"
+      }
+    },
+    "cross-fetch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
+      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "requires": {
+        "node-fetch": "2.6.7"
+      },
+      "dependencies": {
+        "node-fetch": {
+          "version": "2.6.7",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
+          "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+          "requires": {
+            "whatwg-url": "^5.0.0"
+          }
+        }
       }
     },
     "cross-spawn": {
@@ -13658,6 +13844,11 @@
         }
       }
     },
+    "extract-files": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/extract-files/-/extract-files-9.0.0.tgz",
+      "integrity": "sha512-CvdFfHkC95B4bBBk36hcEmvdR2awOdhhVUYH6S/zrVj3477zven/fJMYg7121h4T1xHZC+tetUpubpAhxwI7hQ=="
+    },
     "extsprintf": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
@@ -13746,9 +13937,9 @@
       "integrity": "sha1-Hxik2TgVLUlZZfnJWNkjqy3WabQ="
     },
     "follow-redirects": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.1.tgz",
-      "integrity": "sha512-HWqDgT7ZEkqRzBvc2s64vSZ/hfOceEol3ac/7tKwzuvEyWx3/4UegXh5oBOIotkGsObyk3xznnSRVADBgWSQVg=="
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.1.tgz",
+      "integrity": "sha512-yLAMQs+k0b2m7cVxpS1VKJVvoz7SS9Td1zss3XRwXj+ZDH00RJgnuLx7E44wx02kQLrdM3aOOy+FpzS7+8OizA=="
     },
     "forever-agent": {
       "version": "0.6.1",
@@ -14006,9 +14197,31 @@
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ=="
     },
     "graphql": {
-      "version": "15.5.0",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
-      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA=="
+      "version": "15.8.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.8.0.tgz",
+      "integrity": "sha512-5gghUc24tP9HRznNpV2+FIoq3xKkj5dTQqf4v0CpdPbFVwFkWoxOM+o+2OC9ZSvjEMTjfmG9QT+gcvggTwW1zw=="
+    },
+    "graphql-request": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/graphql-request/-/graphql-request-3.7.0.tgz",
+      "integrity": "sha512-dw5PxHCgBneN2DDNqpWu8QkbbJ07oOziy8z+bK/TAXufsOLaETuVO4GkXrbs0WjhdKhBMN3BkpN/RIvUHkmNUQ==",
+      "requires": {
+        "cross-fetch": "^3.0.6",
+        "extract-files": "^9.0.0",
+        "form-data": "^3.0.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-3.0.1.tgz",
+          "integrity": "sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "har-schema": {
       "version": "2.0.0",
@@ -18157,6 +18370,11 @@
         "punycode": "^2.1.1"
       }
     },
+    "tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
     "true-case-path": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/true-case-path/-/true-case-path-2.2.1.tgz",
@@ -18423,6 +18641,20 @@
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
           "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA=="
         }
+      }
+    },
+    "webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "requires": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
     "@graphprotocol/graph-ts": "0.25.0",
     "@graphql-tools/merge": "^8.2.1",
     "chalk": "4.1.2",
+    "codegen-graph-ts": "^0.1.4",
     "commander": "8.2.0",
     "eslint-config-prettier": "^8.3.0",
     "mustache": "4.2.0",

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -73,6 +73,14 @@ type FuturesCumulativeStat @entity {
   averageTradeSize: BigInt!
 }
 
+type FuturesHourlyStat @entity {
+  id: ID!
+  asset: Bytes!
+  trades: BigInt!
+  volume: BigInt!
+  timestamp: BigInt!
+}
+
 type FuturesOneMinStat @entity {
   id: ID!
   trades: BigInt!

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -233,8 +233,17 @@ type FuturesCumulativeStat @entity {
   id: ID!
   totalLiquidations: BigInt!
   totalTrades: BigInt!
+  totalTraders: BigInt!
   totalVolume: BigInt!
   averageTradeSize: BigInt!
+}
+
+type FuturesHourlyStat @entity {
+  id: ID!
+  asset: Bytes!
+  trades: BigInt!
+  volume: BigInt!
+  timestamp: BigInt!
 }
 
 type FuturesOneMinStat @entity {


### PR DESCRIPTION
Adds a new entity that tracks trades and volume for each perp market. These entities will help to avoid aggregations on the frontend.

For example, to get daily trading volume we can sum the past 24 hourly values instead of counting the number of records returned from a query returning all trades in 24 hours.