### PR TITLE
Fix CM account entity

### DIFF
--- a/src/crossmargin.ts
+++ b/src/crossmargin.ts
@@ -16,7 +16,7 @@ import {
   FuturesTrade,
   CrossMarginAccountTransfer,
 } from '../generated/subgraphs/futures/schema';
-import { BPS_CONVERSION, ETHER } from './lib/helpers';
+import { BPS_CONVERSION, ETHER, ZERO_ADDRESS } from './lib/helpers';
 
 // temporary cross-margin fee solution
 let CROSSMARGIN_ADVANCED_ORDER_BPS = BigInt.fromI32(3);
@@ -130,9 +130,9 @@ export function handleOrderCancelled(event: OrderCancelledEvent): void {
 }
 
 export function handleDeposit(event: DepositEvent): void {
-  let sendingAccount = event.params.user;
-  let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
-  if (crossMarginAccount) {
+  let sendingAccount = event.transaction.to;
+  let crossMarginAccount = CrossMarginAccount.load(sendingAccount ? sendingAccount.toHex() : '');
+  if (sendingAccount && crossMarginAccount) {
     const accountOwner = crossMarginAccount.owner;
 
     let crossMarginTransfer = new CrossMarginAccountTransfer(
@@ -148,9 +148,9 @@ export function handleDeposit(event: DepositEvent): void {
 }
 
 export function handleWithdraw(event: WithdrawEvent): void {
-  let sendingAccount = event.params.user;
-  let crossMarginAccount = CrossMarginAccount.load(sendingAccount.toHex());
-  if (crossMarginAccount) {
+  let sendingAccount = event.transaction.to;
+  let crossMarginAccount = CrossMarginAccount.load(sendingAccount ? sendingAccount.toHex() : '');
+  if (sendingAccount && crossMarginAccount) {
     const accountOwner = crossMarginAccount.owner;
 
     let crossMarginTransfer = new CrossMarginAccountTransfer(

--- a/src/crossmargin.ts
+++ b/src/crossmargin.ts
@@ -16,7 +16,7 @@ import {
   FuturesTrade,
   CrossMarginAccountTransfer,
 } from '../generated/subgraphs/futures/schema';
-import { BPS_CONVERSION, ETHER, ZERO_ADDRESS } from './lib/helpers';
+import { BPS_CONVERSION, ETHER } from './lib/helpers';
 
 // temporary cross-margin fee solution
 let CROSSMARGIN_ADVANCED_ORDER_BPS = BigInt.fromI32(3);

--- a/subgraphs/futures.js
+++ b/subgraphs/futures.js
@@ -177,6 +177,14 @@ const marginBaseTemplate = {
         event: 'OrderFilled(indexed address,uint256,uint256,uint256)',
         handler: 'handleOrderFilled',
       },
+      {
+        event: 'Deposit(indexed address,uint256)',
+        handler: 'handleDeposit',
+      },
+      {
+        event: 'Withdraw(indexed address,uint256)',
+        handler: 'handleWithdraw',
+      },
     ],
   },
 };


### PR DESCRIPTION
Previous change fetched the `CrossMarginAccount` entity using the account owners address instead of the `MarginBase` address