### PR TITLE
Add cross margin account fees to aggregates

### DIFF
--- a/src/crossmargin.ts
+++ b/src/crossmargin.ts
@@ -102,7 +102,15 @@ export function handleOrderFilled(event: OrderFilledEvent): void {
           .div(BPS_CONVERSION);
         tradeEntity.feesPaid = tradeEntity.feesPaid.plus(feePaid);
 
-        updateAggregateStatEntities(positionEntity.asset, event.block.timestamp, ZERO, ZERO, ZERO, feePaid);
+        updateAggregateStatEntities(
+          'cross_margin',
+          positionEntity.asset,
+          event.block.timestamp,
+          ZERO,
+          ZERO,
+          ZERO,
+          feePaid,
+        );
 
         positionEntity.feesPaid = positionEntity.feesPaid.plus(feePaid);
         positionEntity.pnlWithFeesPaid = positionEntity.pnl

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -91,6 +91,7 @@ type FuturesAggregateStat @entity {
   volume: BigInt!
   feesKwenta: BigInt!
   feesSynthetix: BigInt!
+  feesCrossMarginAccounts: BigInt!
 }
 
 type FuturesMarginTransfer @entity {


### PR DESCRIPTION
Add a field to the aggregate entities that totals fees paid using cross margin accounts, to be used in the trading rewards calculations.