### PR TITLE
Add market keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,3 +233,12 @@ The CLI automatically generates the main subgraph, which is composed of the othe
 All of the prompts in the CLI can be provided via options. For more information, run `npm run deploy -- --help`.
 
 PRs to the `main` branch of this repository will result in deploys of main subgraphs to each network: Optimism mainnet, Optimism kovan, and Ethereum mainnet.
+
+### Codegen
+
+To generate a set of subgraph functions for a frontend, use the following commands but replace the endpoint:
+
+```
+npx codegen-graph-ts pull https://api.thegraph.com/subgraphs/name/example-team/example-subgraph > manifest.json
+npx codegen-graph-ts gen -s manifest.json -o subgraph.ts
+```

--- a/src/crossmargin.ts
+++ b/src/crossmargin.ts
@@ -104,6 +104,7 @@ export function handleOrderFilled(event: OrderFilledEvent): void {
 
         updateAggregateStatEntities(
           'cross_margin',
+          positionEntity.marketKey,
           positionEntity.asset,
           event.block.timestamp,
           ZERO,

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -1,6 +1,7 @@
 type FuturesMarket @entity {
   id: ID!
   asset: Bytes!
+  marketKey: Bytes!
   marketStats: FuturesCumulativeStat!
 }
 
@@ -13,6 +14,7 @@ type FuturesTrade @entity {
   margin: BigInt!
   size: BigInt!
   asset: Bytes!
+  marketKey: Bytes!
   price: BigInt!
   positionId: ID!
   positionSize: BigInt!
@@ -30,6 +32,7 @@ type FuturesPosition @entity {
   timestamp: BigInt!
   market: Bytes!
   asset: Bytes!
+  marketKey: Bytes!
   account: Bytes!
   abstractAccount: Bytes!
   accountType: FuturesAccountType!
@@ -74,18 +77,11 @@ type FuturesCumulativeStat @entity {
   averageTradeSize: BigInt!
 }
 
-type FuturesHourlyStat @entity {
-  id: ID!
-  asset: Bytes!
-  trades: BigInt!
-  volume: BigInt!
-  timestamp: BigInt!
-}
-
 type FuturesAggregateStat @entity {
   id: ID!
   period: BigInt!
   timestamp: BigInt!
+  marketKey: Bytes!
   asset: Bytes!
   trades: BigInt!
   volume: BigInt!

--- a/subgraphs/main.graphql
+++ b/subgraphs/main.graphql
@@ -166,6 +166,7 @@ type Candle @entity {
 type FuturesMarket @entity {
   id: ID!
   asset: Bytes!
+  marketKey: Bytes!
   marketStats: FuturesCumulativeStat!
 }
 
@@ -178,6 +179,7 @@ type FuturesTrade @entity {
   margin: BigInt!
   size: BigInt!
   asset: Bytes!
+  marketKey: Bytes!
   price: BigInt!
   positionId: ID!
   positionSize: BigInt!
@@ -195,6 +197,7 @@ type FuturesPosition @entity {
   timestamp: BigInt!
   market: Bytes!
   asset: Bytes!
+  marketKey: Bytes!
   account: Bytes!
   abstractAccount: Bytes!
   accountType: FuturesAccountType!
@@ -239,19 +242,17 @@ type FuturesCumulativeStat @entity {
   averageTradeSize: BigInt!
 }
 
-type FuturesHourlyStat @entity {
+type FuturesAggregateStat @entity {
   id: ID!
+  period: BigInt!
+  timestamp: BigInt!
+  marketKey: Bytes!
   asset: Bytes!
   trades: BigInt!
   volume: BigInt!
-  timestamp: BigInt!
-}
-
-type FuturesOneMinStat @entity {
-  id: ID!
-  trades: BigInt!
-  volume: BigInt!
-  timestamp: BigInt!
+  feesKwenta: BigInt!
+  feesSynthetix: BigInt!
+  feesCrossMarginAccounts: BigInt!
 }
 
 type FuturesMarginTransfer @entity {


### PR DESCRIPTION
Add market key to entities:
- `FuturesMarket`
- `FuturesPosition`
- `FuturesTrade`
- `FuturesAggregateStat`

Additionally, we can deprecate and remove the `FuturesHourlyStat` entity, as it has been replace by the aggregates and deprecated in frontend queries.

This key will allow us to distinguish V1 perp markets from V2, which _may_ have the same asset key but different market keys.