### PR TITLE
Add `fundingPayments` entity 

### DIFF
--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -21,6 +21,7 @@ type FuturesTrade @entity {
   positionClosed: Boolean!
   pnl: BigInt!
   feesPaid: BigInt!
+  fundingAccrued: BigInt!
   keeperFeesPaid: BigInt!
   orderType: FuturesOrderType!
   trackingCode: Bytes!
@@ -112,6 +113,16 @@ type FuturesMarginAccount @entity {
   margin: BigInt!
   deposits: BigInt!
   withdrawals: BigInt!
+}
+
+type FundingPayment @entity {
+  id: ID!
+  timestamp: BigInt!
+  account: Bytes!
+  positionId: ID!
+  marketKey: Bytes!
+  asset: Bytes!
+  amount: BigInt!
 }
 
 type FundingRateUpdate @entity {


### PR DESCRIPTION
Add a `fundingPayments` entity which tracks any time funding is accrued to a position. This will help track individual realized funding across a position, since it can be realized during margin transfers or order submissions.