### PR TITLE
Smart margin: track accounts

### DIFF
--- a/abis/Events.json
+++ b/abis/Events.json
@@ -1,0 +1,404 @@
+[
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IAccount.ConditionalOrderCancelledReason",
+        "name": "reason",
+        "type": "uint8"
+      }
+    ],
+    "name": "ConditionalOrderCancelled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "fillPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "keeperFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "ConditionalOrderFilled",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "marketKey",
+        "type": "bytes32"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "marginDelta",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "int256",
+        "name": "sizeDelta",
+        "type": "int256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "targetPrice",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "enum IAccount.ConditionalOrderTypes",
+        "name": "conditionalOrderType",
+        "type": "uint8"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint128",
+        "name": "priceImpactDelta",
+        "type": "uint128"
+      },
+      {
+        "indexed": false,
+        "internalType": "bool",
+        "name": "reduceOnly",
+        "type": "bool"
+      }
+    ],
+    "name": "ConditionalOrderPlaced",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Deposit",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "EthWithdraw",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "FeeImposed",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "Withdraw",
+    "type": "event"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum IAccount.ConditionalOrderCancelledReason",
+        "name": "reason",
+        "type": "uint8"
+      }
+    ],
+    "name": "emitConditionalOrderCancelled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "fillPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "keeperFee",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitConditionalOrderFilled",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "conditionalOrderId",
+        "type": "uint256"
+      },
+      {
+        "internalType": "bytes32",
+        "name": "marketKey",
+        "type": "bytes32"
+      },
+      {
+        "internalType": "int256",
+        "name": "marginDelta",
+        "type": "int256"
+      },
+      {
+        "internalType": "int256",
+        "name": "sizeDelta",
+        "type": "int256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "targetPrice",
+        "type": "uint256"
+      },
+      {
+        "internalType": "enum IAccount.ConditionalOrderTypes",
+        "name": "conditionalOrderType",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint128",
+        "name": "priceImpactDelta",
+        "type": "uint128"
+      },
+      {
+        "internalType": "bool",
+        "name": "reduceOnly",
+        "type": "bool"
+      }
+    ],
+    "name": "emitConditionalOrderPlaced",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitDeposit",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitEthWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitFeeImposed",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "amount",
+        "type": "uint256"
+      }
+    ],
+    "name": "emitWithdraw",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/abis/Factory.json
+++ b/abis/Factory.json
@@ -1,0 +1,333 @@
+[
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_owner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_settings",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_events",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_implementation",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "constructor"
+  },
+  {
+    "inputs": [],
+    "name": "AccountDoesNotExist",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "AccountFailedToFetchVersion",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "AccountFailedToInitialize",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CallerMustBeAccount",
+    "type": "error"
+  },
+  {
+    "inputs": [],
+    "name": "CannotUpgrade",
+    "type": "error"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "OnlyOneAccountPerAddress",
+    "type": "error"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "implementation",
+        "type": "address"
+      }
+    ],
+    "name": "AccountImplementationUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "events",
+        "type": "address"
+      }
+    ],
+    "name": "EventsUpgraded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "creator",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "bytes32",
+        "name": "version",
+        "type": "bytes32"
+      }
+    ],
+    "name": "NewAccount",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "user",
+        "type": "address"
+      },
+      {
+        "indexed": true,
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "OwnershipTransferred",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "settings",
+        "type": "address"
+      }
+    ],
+    "name": "SettingsUpgraded",
+    "type": "event"
+  },
+  {
+    "inputs": [],
+    "name": "canUpgrade",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "events",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "newAccount",
+    "outputs": [
+      {
+        "internalType": "address payable",
+        "name": "accountAddress",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "owner",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "accountOwner",
+        "type": "address"
+      }
+    ],
+    "name": "ownerToAccount",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "removeUpgradability",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "settings",
+    "outputs": [
+      {
+        "internalType": "address",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "transferOwnership",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_oldOwner",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "_newOwner",
+        "type": "address"
+      }
+    ],
+    "name": "updateAccountOwner",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_implementation",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeAccountImplementation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_events",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeEvents",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_settings",
+        "type": "address"
+      }
+    ],
+    "name": "upgradeSettings",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  }
+]

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prepare": "husky install",
     "auth": "graph auth --product hosted-service",
     "deploy": "node ./scripts/deploy.js",
-    "build": "node ./scripts/deploy.js --build-only --team noneya --network optimism"
+    "build": "node ./scripts/deploy.js --build-only --team noneya --network optimism --provider hosted_service --version 0.0.1-test"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"

--- a/src/smartmargin.ts
+++ b/src/smartmargin.ts
@@ -1,0 +1,16 @@
+import { Address } from '@graphprotocol/graph-ts';
+import { NewAccount as NewAccountEvent } from '../generated/subgraphs/perps/smartmargin_factory/Factory';
+import { SmartMarginAccount } from '../generated/subgraphs/futures/schema';
+
+export function handleNewAccount(event: NewAccountEvent): void {
+  // create a new entity to store the cross-margin account owner
+  const cmAccountAddress = event.params.account as Address;
+  let smartMarginAccount = SmartMarginAccount.load(cmAccountAddress.toHex());
+
+  if (smartMarginAccount == null) {
+    smartMarginAccount = new SmartMarginAccount(cmAccountAddress.toHex());
+    smartMarginAccount.owner = event.params.creator;
+    smartMarginAccount.version = event.params.version;
+    smartMarginAccount.save();
+  }
+}

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -181,6 +181,12 @@ type CrossMarginAccount @entity {
   owner: Bytes!
 }
 
+type SmartMarginAccount @entity {
+  id: ID!
+  owner: Bytes!
+  version: Bytes!
+}
+
 type CrossMarginAccountTransfer @entity {
   id: ID!
   account: Bytes!

--- a/subgraphs/futures.graphql
+++ b/subgraphs/futures.graphql
@@ -68,7 +68,7 @@ type FuturesStat @entity {
   liquidations: BigInt!
   totalTrades: BigInt!
   totalVolume: BigInt!
-  crossMarginVolume: BigInt!
+  smartMarginVolume: BigInt!
 }
 
 type FuturesCumulativeStat @entity {
@@ -155,7 +155,7 @@ enum FuturesOrderStatus {
 
 enum FuturesAccountType {
   isolated_margin
-  cross_margin
+  smart_margin
 }
 
 type FuturesOrder @entity {

--- a/subgraphs/perps.js
+++ b/subgraphs/perps.js
@@ -23,7 +23,6 @@ const testnetConfig = {
 
 const config = currentNetwork === 'optimism' ? mainnetConfig : testnetConfig;
 
-console.log(config);
 // futures market manager
 getContractDeployments('FuturesMarketManager').forEach((a, i) => {
   manifest.push({

--- a/subgraphs/perps.js
+++ b/subgraphs/perps.js
@@ -2,18 +2,28 @@ const { getCurrentNetwork, getContractDeployments } = require('./utils/network')
 
 const manifest = [];
 
-START_BLOCK_OP_GOERLI = 3495320;
-START_BLOCK_OP_MAINNET = 52456507;
-
+// get config
 const currentNetwork = getCurrentNetwork();
 
-const managerStartBlock =
-  currentNetwork === 'optimism'
-    ? START_BLOCK_OP_MAINNET
-    : currentNetwork === 'optimism-goerli'
-    ? START_BLOCK_OP_GOERLI
-    : 0;
+const mainnetConfig = {
+  managerStartBlock: 52456507,
+  smartMarginFactoryAddress: '0xa5Aac6b5De821E631C7Ad01f978e32e80a8461c7',
+  smartMarginFactoryStartBlock: 78921742,
+  smartMarginEventsAddress: '0x319Ae7F3a0D635eD9CCF0276dCeAF680F9C7c397',
+  smartMarginEventsStartBlock: 78921720,
+};
 
+const testnetConfig = {
+  managerStartBlock: 3495320,
+  smartMarginFactoryAddress: '0xfc026f2230C55DC8BDE3bD9bE8941fbDCA6B39C2',
+  smartMarginFactoryStartBlock: 6434063,
+  smartMarginEventsAddress: '0x78016932540193e2E80683B8F9Be222729eF08D4',
+  smartMarginEventsStartBlock: 6434056,
+};
+
+const config = currentNetwork === 'optimism' ? mainnetConfig : testnetConfig;
+
+console.log(config);
 // futures market manager
 getContractDeployments('FuturesMarketManager').forEach((a, i) => {
   manifest.push({
@@ -22,7 +32,7 @@ getContractDeployments('FuturesMarketManager').forEach((a, i) => {
     network: currentNetwork,
     source: {
       address: a.address,
-      startBlock: managerStartBlock,
+      startBlock: config.managerStartBlock,
       abi: 'FuturesMarketManager',
     },
     mapping: {
@@ -103,6 +113,37 @@ const perpsMarketTemplate = {
     ],
   },
 };
+
+// smart margin
+manifest.push({
+  kind: 'ethereum/contract',
+  name: 'smartmargin_factory',
+  network: getCurrentNetwork(),
+  source: {
+    address: config.smartMarginFactoryAddress,
+    startBlock: config.smartMarginFactoryStartBlock,
+    abi: 'Factory',
+  },
+  mapping: {
+    kind: 'ethereum/events',
+    apiVersion: '0.0.6',
+    language: 'wasm/assemblyscript',
+    file: '../src/smartmargin.ts',
+    entities: ['Factory'],
+    abis: [
+      {
+        name: 'Factory',
+        file: '../abis/Factory.json',
+      },
+    ],
+    eventHandlers: [
+      {
+        event: 'NewAccount(indexed address,indexed address,bytes32)',
+        handler: 'handleNewAccount',
+      },
+    ],
+  },
+});
 
 module.exports = {
   specVersion: '0.0.4',


### PR DESCRIPTION
## Description
This change enables listening for smart margin account events. Currently this version will track the creation of new accounts, and tagging activity coming from smart margin accounts.

* Add `Factory` and `Events` contract ABIs
* Listen to `Factory` for `NewAccount` events
* Replace `crossMarginAccount` tracking with `smartMarginAccount` tracking