### PR TITLE
Added delegatedAccount entity to perps-v3

### DIFF
--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -112,3 +112,12 @@ enum FundingRatePeriodType {
   Hourly
   Daily
 }
+
+type DelegatedAccount @entity {
+  id: ID!
+  caller: Bytes! # address
+  delegate: Bytes! # address
+  blockNumber: BigInt!
+  blockTimestamp: BigInt!
+  transactionHash: Bytes!
+}

--- a/subgraphs/perps-v3.js
+++ b/subgraphs/perps-v3.js
@@ -19,7 +19,7 @@ manifest.push({
     apiVersion: '0.0.6',
     language: 'wasm/assemblyscript',
     file: '../src/perps-v3.ts',
-    entities: ['Account', 'OrderSettled'],
+    entities: ['Account', 'OrderSettled', 'DelegatedAccount'],
     abis: [
       {
         name: 'PerpsV3MarketProxy',
@@ -58,12 +58,20 @@ manifest.push({
         event: 'MarketUpdated(uint128,uint256,int256,uint256,int256,int256,int256)',
         handler: 'handleFundingRecomputed',
       },
+      {
+        event: 'PermissionGranted(indexed uint128,indexed bytes32,indexed address,address)',
+        handler: 'handlePermissionGranted',
+      },
+      {
+        event: 'PermissionRevoked(indexed uint128,indexed bytes32,indexed address,address)',
+        handler: 'handlePermissionRevoked',
+      },
     ],
   },
 });
 
 module.exports = {
-  specVersion: '0.0.4',
+  specVersion: '0.0.5',
   description: 'Kwenta Perps V3 API',
   repository: 'https://github.com/kwenta/kwenta-subgraph',
   schema: {


### PR DESCRIPTION
Following the same logic in #160, we use a single entity to track the `PermissionGranted` and `PermissionRevoked` events.

Deployment: https://subgraphs.alchemy.com/subgraphs/1852/versions/8739 
Playground: https://subgraph.satsuma-prod.com/kwenta/base-testnet-perps-v3/version/0.0.7/playground