### PR TITLE
[V3] Add trades to PerpsV3AggregateStat

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -26,6 +26,7 @@ import {
   ETHER,
   FUNDING_RATE_PERIODS,
   FUNDING_RATE_PERIOD_TYPES,
+  ONE,
   ONE_HOUR_SECONDS,
   ZERO,
   getTimeID,
@@ -143,7 +144,13 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     positionEntity.pnlWithFeesPaid = ZERO;
     positionEntity.totalVolume = volume;
 
-    updateAggregateStatEntities(positionEntity.marketId, positionEntity.marketSymbol, event.block.timestamp, volume);
+    updateAggregateStatEntities(
+      positionEntity.marketId,
+      positionEntity.marketSymbol,
+      event.block.timestamp,
+      ONE,
+      volume,
+    );
 
     positionEntity.save();
   } else {
@@ -181,7 +188,13 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     positionEntity.netFunding = positionEntity.netFunding.plus(event.params.accruedFunding);
     positionEntity.size = positionEntity.size.plus(event.params.sizeDelta);
 
-    updateAggregateStatEntities(positionEntity.marketId, positionEntity.marketSymbol, event.block.timestamp, volume);
+    updateAggregateStatEntities(
+      positionEntity.marketId,
+      positionEntity.marketSymbol,
+      event.block.timestamp,
+      ONE,
+      volume,
+    );
 
     positionEntity.save();
   }
@@ -349,6 +362,7 @@ function getOrCreateMarketAggregateStats(
     aggregateEntity.timestamp = timestamp;
     aggregateEntity.marketId = marketId;
     aggregateEntity.marketSymbol = marketSymbol;
+    aggregateEntity.trades = ZERO;
     aggregateEntity.volume = ZERO;
   }
   return aggregateEntity as PerpsV3AggregateStat;
@@ -358,6 +372,7 @@ export function updateAggregateStatEntities(
   marketId: BigInt,
   marketSymbol: string,
   timestamp: BigInt,
+  trades: BigInt,
   volume: BigInt,
 ): void {
   // this function updates the aggregate stat entities for the specified account and market
@@ -370,6 +385,7 @@ export function updateAggregateStatEntities(
 
     // update the aggregate for this market
     let aggStats = getOrCreateMarketAggregateStats(marketId, marketSymbol, aggTimestamp, thisPeriod);
+    aggStats.trades = aggStats.trades.plus(trades);
     aggStats.volume = aggStats.volume.plus(volume);
     aggStats.save();
   }

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -137,5 +137,6 @@ type PerpsV3AggregateStat @entity {
   timestamp: BigInt!
   marketId: BigInt!
   marketSymbol: String!
+  trades: BigInt!
   volume: BigInt!
 }


### PR DESCRIPTION
- Track the trades in `PerpsV3AggregateStat`

Note: the change was made locally in #170 and already deployed to base-testnet-perps-v3/0.0.13 (live) and base-perps-v3/0.0.5 (live). 