### PR TITLE
Move perps v3 test subgraph from base goerli to base sepolia

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -36,7 +36,7 @@ program
 
 program.action(async () => {
   const MAIN_SUBGRAPH_EXCLUDE = [];
-  const NETWORK_CHOICES = ['mainnet', 'goerli', 'optimism', 'optimism-goerli', 'base', 'base-testnet'];
+  const NETWORK_CHOICES = ['mainnet', 'goerli', 'optimism', 'optimism-goerli', 'base', 'base-sepolia'];
   const SUBGRAPH_CHOICES = await fs.readdirSync(path.join(__dirname, '../subgraphs')).reduce((acc, val) => {
     if (val.endsWith('.js') && val !== 'main.js') {
       acc.push(val.slice(0, -3));

--- a/subgraphs/perps-v3.js
+++ b/subgraphs/perps-v3.js
@@ -12,14 +12,14 @@ const mainnetConfig = {
   },
 };
 
-const testnetConfig = {
+const sepoliaConfig = {
   marketProxy: {
-    address: '0x75c43165ea38cB857C45216a37C5405A7656673c',
-    startBlock: 13044488,
+    address: '0xE6C5f05C415126E6b81FCc3619f65Db2fCAd58D0',
+    startBlock: 4548969,
   },
 };
 
-const config = currentNetwork === 'base' ? mainnetConfig : testnetConfig;
+const config = currentNetwork === 'base' ? mainnetConfig : sepoliaConfig;
 
 manifest.push({
   kind: 'ethereum/contract',

--- a/subgraphs/utils/network.js
+++ b/subgraphs/utils/network.js
@@ -136,7 +136,7 @@ function getFuturesMarkets(network = 'optimism') {
   return futuresMarkets.map(({ marketKey }) => marketKey.substring(1) /* Slicing off the `s` from marketKey */);
 }
 
-const NETWORKS = ['mainnet', 'goerli', 'optimism-goerli', 'optimism', 'base', 'base-testnet'];
+const NETWORKS = ['mainnet', 'goerli', 'optimism-goerli', 'optimism', 'base', 'base-sepolia'];
 
 module.exports = {
   getCurrentNetwork,


### PR DESCRIPTION
Add base sepolia and bse goerli for perps v3
Deployment: [base-sepolia-perps-v3 0.0.1](https://subgraphs.alchemy.com/subgraphs/3903)