### PR TITLE
Fix the account id for leaderboard data

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -79,7 +79,7 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     return;
   }
 
-  let statEntity = PerpsV3Stat.load(account.owner.toHex());
+  let statEntity = PerpsV3Stat.load(event.params.accountId.toString());
 
   if (openPosition === null) {
     log.warning('Position entity not found for positionId {}', [positionId]);
@@ -146,10 +146,10 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     return;
   }
 
-  let statEntity = PerpsV3Stat.load(account.owner.toHex());
+  let statEntity = PerpsV3Stat.load(event.params.accountId.toString());
 
   if (statEntity == null) {
-    statEntity = new PerpsV3Stat(account.owner.toHex());
+    statEntity = new PerpsV3Stat(event.params.accountId.toString());
     statEntity.account = account.owner;
     statEntity.feesPaid = ZERO;
     statEntity.pnl = ZERO;

--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -152,7 +152,7 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
 
   if (statEntity == null) {
     statEntity = new PerpsV3Stat(statId);
-    statEntity.account = event.params.accountId;
+    statEntity.accountId = event.params.accountId;
     statEntity.accountOwner = account.owner;
     statEntity.feesPaid = ZERO;
     statEntity.pnl = ZERO;

--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -79,7 +79,8 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     return;
   }
 
-  let statEntity = PerpsV3Stat.load(event.params.accountId.toString());
+  let statId = event.params.accountId.toString() + '-' + account.owner.toHexString();
+  let statEntity = PerpsV3Stat.load(statId);
 
   if (openPosition === null) {
     log.warning('Position entity not found for positionId {}', [positionId]);
@@ -146,11 +147,13 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     return;
   }
 
-  let statEntity = PerpsV3Stat.load(event.params.accountId.toString());
+  let statId = event.params.accountId.toString() + '-' + account.owner.toHexString();
+  let statEntity = PerpsV3Stat.load(statId);
 
   if (statEntity == null) {
-    statEntity = new PerpsV3Stat(event.params.accountId.toString());
-    statEntity.account = account.owner;
+    statEntity = new PerpsV3Stat(statId);
+    statEntity.account = event.params.accountId;
+    statEntity.accountOwner = account.owner;
     statEntity.feesPaid = ZERO;
     statEntity.pnl = ZERO;
     statEntity.pnlWithFeesPaid = ZERO;

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -158,7 +158,7 @@ type CollateralChange @entity {
 
 type PerpsV3Stat @entity {
   id: ID!
-  account: BigInt!
+  accountId: BigInt!
   accountOwner: Bytes!
   feesPaid: BigInt!
   pnl: BigInt!

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -158,7 +158,8 @@ type CollateralChange @entity {
 
 type PerpsV3Stat @entity {
   id: ID!
-  account: Bytes!
+  account: BigInt!
+  accountOwner: Bytes!
   feesPaid: BigInt!
   pnl: BigInt!
   pnlWithFeesPaid: BigInt!


### PR DESCRIPTION
This PR fixes an issue where perpsV3Stat's id was incorrectly identified as the account owner instead of the account id.

- base-perps-v3 0.0.10: https://subgraphs.alchemy.com/subgraphs/3183/versions/13154
- base-sepolia-perps-v3 0.0.4: https://subgraphs.alchemy.com/subgraphs/3903/versions/13153