### PR TITLE
reference trades to position

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -112,6 +112,7 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     let positionEntity = PerpsV3Position.load(openPosition.position!);
     if (positionEntity !== null) {
       positionEntity.isLiquidated = true;
+      positionEntity.liquidation = liquidation.id;
       positionEntity.isOpen = false;
       openPosition.position = null;
       positionEntity.save();

--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -211,6 +211,7 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     positionEntity.openTimestamp = event.block.timestamp;
     positionEntity.avgEntryPrice = event.params.fillPrice;
     positionEntity.totalTrades = BigInt.fromI32(1);
+    positionEntity.trades = [order.id];
     positionEntity.entryPrice = event.params.fillPrice;
     positionEntity.lastPrice = event.params.fillPrice;
     positionEntity.realizedPnl = ZERO;
@@ -248,6 +249,7 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
       calculatePnl(positionEntity, order, event, statEntity);
     } else {
       positionEntity.totalTrades = positionEntity.totalTrades.plus(BigInt.fromI32(1));
+      positionEntity.trades.push(order.id);
       positionEntity.totalVolume = positionEntity.totalVolume.plus(volume);
 
       statEntity.totalTrades = statEntity.totalTrades.plus(BigInt.fromI32(1));

--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -259,7 +259,10 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
       calculatePnl(positionEntity, order, event, statEntity);
     } else {
       positionEntity.totalTrades = positionEntity.totalTrades.plus(BigInt.fromI32(1));
-      positionEntity.trades.push(order.id);
+
+      const trades = positionEntity.trades;
+      trades.push(order.id);
+      positionEntity.trades = trades;
       positionEntity.totalVolume = positionEntity.totalVolume.plus(volume);
 
       statEntity.totalTrades = statEntity.totalTrades.plus(BigInt.fromI32(1));

--- a/src/perps.ts
+++ b/src/perps.ts
@@ -298,7 +298,11 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
 
     // update position stats
     positionEntity.trades = positionEntity.trades.plus(BigInt.fromI32(1));
-    positionEntity.allTrades.push(tradeEntity.id);
+
+    const trades = positionEntity.allTrades;
+    trades.push(tradeEntity.id);
+    positionEntity.allTrades = trades;
+
     positionEntity.totalVolume = positionEntity.totalVolume.plus(volume);
 
     // update cumulative and aggregate stats

--- a/src/perps.ts
+++ b/src/perps.ts
@@ -298,6 +298,7 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
 
     // update position stats
     positionEntity.trades = positionEntity.trades.plus(BigInt.fromI32(1));
+    positionEntity.allTrades.push(tradeEntity.id);
     positionEntity.totalVolume = positionEntity.totalVolume.plus(volume);
 
     // update cumulative and aggregate stats

--- a/src/perps.ts
+++ b/src/perps.ts
@@ -461,7 +461,6 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     // adjust pnl for the additional fees paid
     positionEntity.pnl = positionEntity.pnl.plus(event.params.fee);
     positionEntity.pnlWithFeesPaid = positionEntity.pnl.minus(positionEntity.feesPaid).plus(positionEntity.netFunding);
-    positionEntity.save();
 
     // update stats entity
     if (statEntity) {
@@ -479,7 +478,9 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
       tradeEntity.feesPaid = tradeEntity.feesPaid.plus(event.params.fee);
       tradeEntity.pnl = tradeEntity.pnl.plus(event.params.fee);
       tradeEntity.save();
+      positionEntity.liquidation = tradeEntity.id;
     }
+    positionEntity.save();
   }
 
   // update cumulative entity
@@ -526,7 +527,6 @@ export function handlePositionLiquidatedV2(event: PositionLiquidatedV2Event): vo
     // adjust pnl for the additional fee paid
     positionEntity.pnl = positionEntity.pnl.plus(totalFee);
     positionEntity.pnlWithFeesPaid = positionEntity.pnl.minus(positionEntity.feesPaid).plus(positionEntity.netFunding);
-    positionEntity.save();
 
     // update stats entity
     if (statEntity) {
@@ -544,7 +544,9 @@ export function handlePositionLiquidatedV2(event: PositionLiquidatedV2Event): vo
       tradeEntity.feesPaid = tradeEntity.feesPaid.plus(totalFee);
       tradeEntity.pnl = tradeEntity.pnl.plus(totalFee);
       tradeEntity.save();
+      positionEntity.liquidation = tradeEntity.id;
     }
+    positionEntity.save();
   }
 
   // update cumulative entity

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -77,6 +77,7 @@ type PerpsV3Position @entity {
   isOpen: Boolean!
   isLiquidated: Boolean!
   totalTrades: BigInt!
+  trades: [OrderSettled!]!
   totalVolume: BigInt!
   size: BigInt!
   realizedPnl: BigInt!

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -76,6 +76,7 @@ type PerpsV3Position @entity {
   account: Account!
   isOpen: Boolean!
   isLiquidated: Boolean!
+  liquidation: PositionLiquidation
   totalTrades: BigInt!
   trades: [OrderSettled!]!
   totalVolume: BigInt!

--- a/subgraphs/perps.graphql
+++ b/subgraphs/perps.graphql
@@ -41,6 +41,7 @@ type FuturesPosition @entity {
   accountType: FuturesAccountType!
   isOpen: Boolean!
   isLiquidated: Boolean!
+  liquidation: FuturesTrade
   trades: BigInt!
   allTrades: [FuturesTrade!]!
   totalVolume: BigInt!

--- a/subgraphs/perps.graphql
+++ b/subgraphs/perps.graphql
@@ -42,6 +42,7 @@ type FuturesPosition @entity {
   isOpen: Boolean!
   isLiquidated: Boolean!
   trades: BigInt!
+  allTrades: [FuturesTrade!]!
   totalVolume: BigInt!
   size: BigInt!
   initialMargin: BigInt!


### PR DESCRIPTION
**Description**:
- add field `trades: [OrderSettled!]!` to type `PerpsV3Position` for reference trades in position in PerpsV3
- add field `allTrades: [FuturesTrade!]!` to type `FuturesPosition` for reference trades in position in PerpsV2

**Note**:
In V2, `FuturesPosition` already has a property called trades which saves the count of all trades
