### PR TITLE
reference trade and liquidation to position

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -114,6 +114,7 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     let positionEntity = PerpsV3Position.load(openPosition.position!);
     if (positionEntity !== null) {
       positionEntity.isLiquidated = true;
+      positionEntity.liquidation = liquidation.id;
       positionEntity.isOpen = false;
       openPosition.position = null;
       positionEntity.save();

--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -242,6 +242,7 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     statEntity.totalVolume = statEntity.totalVolume.plus(volume);
 
     positionEntity.save();
+    order.position = positionEntity.id;
     statEntity.save();
   } else {
     const tradeNotionalValue = event.params.sizeDelta.abs().times(event.params.fillPrice);
@@ -261,6 +262,7 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
 
       statEntity.totalTrades = statEntity.totalTrades.plus(BigInt.fromI32(1));
       statEntity.totalVolume = statEntity.totalVolume.plus(volume);
+      order.position = positionEntity.id;
 
       if (
         (positionEntity.size.lt(ZERO) && event.params.newSize.gt(ZERO)) ||

--- a/src/perps.ts
+++ b/src/perps.ts
@@ -281,7 +281,6 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
         }
       }
     }
-    tradeEntity.save();
 
     // update cumulative stats
     let volume = tradeEntity.size.times(tradeEntity.price).div(ETHER).abs();
@@ -299,6 +298,8 @@ export function handlePositionModified(event: PositionModifiedEvent): void {
     // update position stats
     positionEntity.trades = positionEntity.trades.plus(BigInt.fromI32(1));
     positionEntity.totalVolume = positionEntity.totalVolume.plus(volume);
+    tradeEntity.position = positionEntity.id;
+    tradeEntity.save();
 
     // update cumulative and aggregate stats
     const perpsTrackingEntity = PerpsTracking.load(event.transaction.hash.toHex());

--- a/src/perps.ts
+++ b/src/perps.ts
@@ -461,7 +461,6 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
     // adjust pnl for the additional fees paid
     positionEntity.pnl = positionEntity.pnl.plus(event.params.fee);
     positionEntity.pnlWithFeesPaid = positionEntity.pnl.minus(positionEntity.feesPaid).plus(positionEntity.netFunding);
-    positionEntity.save();
 
     // update stats entity
     if (statEntity) {
@@ -479,7 +478,9 @@ export function handlePositionLiquidated(event: PositionLiquidatedEvent): void {
       tradeEntity.feesPaid = tradeEntity.feesPaid.plus(event.params.fee);
       tradeEntity.pnl = tradeEntity.pnl.plus(event.params.fee);
       tradeEntity.save();
+      positionEntity.liquidation = tradeEntity.id;
     }
+    positionEntity.save();
   }
 
   // update cumulative entity
@@ -526,7 +527,6 @@ export function handlePositionLiquidatedV2(event: PositionLiquidatedV2Event): vo
     // adjust pnl for the additional fee paid
     positionEntity.pnl = positionEntity.pnl.plus(totalFee);
     positionEntity.pnlWithFeesPaid = positionEntity.pnl.minus(positionEntity.feesPaid).plus(positionEntity.netFunding);
-    positionEntity.save();
 
     // update stats entity
     if (statEntity) {
@@ -544,7 +544,9 @@ export function handlePositionLiquidatedV2(event: PositionLiquidatedV2Event): vo
       tradeEntity.feesPaid = tradeEntity.feesPaid.plus(totalFee);
       tradeEntity.pnl = tradeEntity.pnl.plus(totalFee);
       tradeEntity.save();
+      positionEntity.liquidation = tradeEntity.id;
     }
+    positionEntity.save();
   }
 
   // update cumulative entity

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -78,6 +78,7 @@ type PerpsV3Position @entity {
   account: Account!
   isOpen: Boolean!
   isLiquidated: Boolean!
+  liquidation: PositionLiquidation
   totalTrades: BigInt!
   trades: [OrderSettled!]! @derivedFrom(field: "position")
   totalVolume: BigInt!

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -208,6 +208,7 @@ type PositionLiquidation @entity {
   amount: BigInt!
   notionalAmount: BigInt!
   estimatedPrice: BigInt!
+  position: PerpsV3Position @derivedFrom(field: "liquidation")
 }
 
 type InterestCharged @entity {

--- a/subgraphs/perps-v3.graphql
+++ b/subgraphs/perps-v3.graphql
@@ -41,6 +41,7 @@ type OrderSettled @entity {
   pnl: BigInt!
   txnHash: String!
   interestCharged: BigInt
+  position: PerpsV3Position
 }
 
 type OrderCommitted @entity {
@@ -78,6 +79,7 @@ type PerpsV3Position @entity {
   isOpen: Boolean!
   isLiquidated: Boolean!
   totalTrades: BigInt!
+  trades: [OrderSettled!]! @derivedFrom(field: "position")
   totalVolume: BigInt!
   size: BigInt!
   realizedPnl: BigInt!

--- a/subgraphs/perps-v3.js
+++ b/subgraphs/perps-v3.js
@@ -13,10 +13,16 @@ const mainnetConfig = {
 };
 
 const sepoliaConfig = {
-  marketProxy: {
-    address: '0xE6C5f05C415126E6b81FCc3619f65Db2fCAd58D0',
-    startBlock: 4548969,
-  },
+  marketProxy: [
+    {
+      address: '0xE6C5f05C415126E6b81FCc3619f65Db2fCAd58D0',
+      startBlock: 4548969,
+    },
+    {
+      address: '0xf53Ca60F031FAf0E347D44FbaA4870da68250c8d',
+      startBlock: 8157661,
+    },
+  ],
 };
 
 const config = currentNetwork === 'base' ? mainnetConfig : sepoliaConfig;

--- a/subgraphs/perps.graphql
+++ b/subgraphs/perps.graphql
@@ -25,6 +25,7 @@ type FuturesTrade @entity {
   keeperFeesPaid: BigInt!
   orderType: FuturesOrderType!
   trackingCode: Bytes!
+  position: FuturesPosition
 }
 
 type FuturesPosition @entity {
@@ -42,6 +43,7 @@ type FuturesPosition @entity {
   isOpen: Boolean!
   isLiquidated: Boolean!
   trades: BigInt!
+  allTrades: [FuturesTrade!]! @derivedFrom(field: "position")
   totalVolume: BigInt!
   size: BigInt!
   initialMargin: BigInt!

--- a/subgraphs/perps.graphql
+++ b/subgraphs/perps.graphql
@@ -42,6 +42,7 @@ type FuturesPosition @entity {
   accountType: FuturesAccountType!
   isOpen: Boolean!
   isLiquidated: Boolean!
+  liquidation: FuturesTrade
   trades: BigInt!
   allTrades: [FuturesTrade!]! @derivedFrom(field: "position")
   totalVolume: BigInt!


### PR DESCRIPTION
**Description**:
- add field trades: [OrderSettled!]! to type PerpsV3Position for reference trades in position in PerpsV3
- add field allTrades: [FuturesTrade!]! to type FuturesPosition for reference trades in position in PerpsV2

**Note**:
In V2, FuturesPosition already has a property called trades which saves the count of all trades