### PR TITLE
Update perps market proxy on base sepolia

### DIFF
--- a/subgraphs/perps-v3.js
+++ b/subgraphs/perps-v3.js
@@ -6,127 +6,139 @@ const manifest = [];
 const currentNetwork = getCurrentNetwork();
 
 const mainnetConfig = {
-  marketProxy: {
-    address: '0x0A2AF931eFFd34b81ebcc57E3d3c9B1E1dE1C9Ce',
-    startBlock: 4382,
-  },
+  marketProxy: [
+    {
+      address: '0x0A2AF931eFFd34b81ebcc57E3d3c9B1E1dE1C9Ce',
+      startBlock: 4382,
+    },
+  ],
 };
 
 const sepoliaConfig = {
-  marketProxy: {
-    address: '0xE6C5f05C415126E6b81FCc3619f65Db2fCAd58D0',
-    startBlock: 4548969,
-  },
+  marketProxy: [
+    {
+      address: '0xE6C5f05C415126E6b81FCc3619f65Db2fCAd58D0',
+      startBlock: 4548969,
+    },
+    {
+      address: '0xf53Ca60F031FAf0E347D44FbaA4870da68250c8d',
+      startBlock: 8157661,
+    },
+  ],
 };
 
 const config = currentNetwork === 'base' ? mainnetConfig : sepoliaConfig;
 
-manifest.push({
-  kind: 'ethereum/contract',
-  name: 'PerpsV3',
-  network: currentNetwork,
-  source: {
-    address: config.marketProxy.address,
-    abi: 'PerpsV3MarketProxy',
-    startBlock: config.marketProxy.startBlock,
-  },
-  mapping: {
-    kind: 'ethereum/events',
-    apiVersion: '0.0.6',
-    language: 'wasm/assemblyscript',
-    file: '../src/perps-v3.ts',
-    entities: ['Account', 'OrderSettled', 'DelegatedAccount'],
-    abis: [
-      {
-        name: 'PerpsV3MarketProxy',
-        file: '../abis/PerpsV3MarketProxy.json',
-      },
-    ],
-    eventHandlers: [
-      {
-        event: 'AccountCreated(indexed uint128,indexed address)',
-        handler: 'handleAccountCreated',
-      },
-      {
-        event:
-          'OrderSettled(indexed uint128,indexed uint128,uint256,int256,int256,int128,int128,uint256,uint256,uint256,uint256,indexed bytes32,address)',
-        handler: 'handleOrderSettled',
-      },
-      {
-        event: 'MarketCreated(indexed uint128,string,string)',
-        handler: 'handleMarketCreated',
-      },
-      {
-        event: 'PositionLiquidated(indexed uint128,indexed uint128,uint256,int128)',
-        handler: 'handlePositionLiquidated',
-      },
-      {
-        event:
-          'SettlementStrategyAdded(indexed uint128,(uint8,uint256,uint256,address,bytes32,uint256,bool,uint256),indexed uint256)',
-        handler: 'handleSettlementStrategyAdded',
-      },
-      {
-        event:
-          'SettlementStrategySet(indexed uint128,indexed uint256,(uint8,uint256,uint256,address,bytes32,uint256,bool,uint256))',
-        handler: 'handleSettlementStrategyEnabled',
-      },
-      {
-        event: 'MarketUpdated(uint128,uint256,int256,uint256,int256,int256,int256,uint128)',
-        handler: 'handleMarketUpdated',
-      },
-      {
-        event: 'PermissionGranted(indexed uint128,indexed bytes32,indexed address,address)',
-        handler: 'handlePermissionGranted',
-      },
-      {
-        event: 'PermissionRevoked(indexed uint128,indexed bytes32,indexed address,address)',
-        handler: 'handlePermissionRevoked',
-      },
-      {
-        event: 'CollateralModified(indexed uint128,indexed uint128,int256,indexed address)',
-        handler: 'handleCollateralModified',
-      },
-      {
-        event:
-          'OrderCommitted(indexed uint128,indexed uint128,uint8,int128,uint256,uint256,uint256,uint256,uint256,indexed bytes32,address)',
-        handler: 'handleOrderCommitted',
-      },
-      {
-        event: 'InterestCharged(indexed uint128,uint256)',
-        handler: 'handleInterestCharged',
-      },
-    ],
-  },
+config.marketProxy.forEach((marketProxy, ind) => {
+  manifest.push({
+    kind: 'ethereum/contract',
+    name: `PerpsV3_${ind}`,
+    network: currentNetwork,
+    source: {
+      address: marketProxy.address,
+      abi: 'PerpsV3MarketProxy',
+      startBlock: marketProxy.startBlock,
+    },
+    mapping: {
+      kind: 'ethereum/events',
+      apiVersion: '0.0.6',
+      language: 'wasm/assemblyscript',
+      file: '../src/perps-v3.ts',
+      entities: ['Account', 'OrderSettled', 'DelegatedAccount'],
+      abis: [
+        {
+          name: 'PerpsV3MarketProxy',
+          file: '../abis/PerpsV3MarketProxy.json',
+        },
+      ],
+      eventHandlers: [
+        {
+          event: 'AccountCreated(indexed uint128,indexed address)',
+          handler: 'handleAccountCreated',
+        },
+        {
+          event:
+            'OrderSettled(indexed uint128,indexed uint128,uint256,int256,int256,int128,int128,uint256,uint256,uint256,uint256,indexed bytes32,address)',
+          handler: 'handleOrderSettled',
+        },
+        {
+          event: 'MarketCreated(indexed uint128,string,string)',
+          handler: 'handleMarketCreated',
+        },
+        {
+          event: 'PositionLiquidated(indexed uint128,indexed uint128,uint256,int128)',
+          handler: 'handlePositionLiquidated',
+        },
+        {
+          event:
+            'SettlementStrategyAdded(indexed uint128,(uint8,uint256,uint256,address,bytes32,uint256,bool,uint256),indexed uint256)',
+          handler: 'handleSettlementStrategyAdded',
+        },
+        {
+          event:
+            'SettlementStrategySet(indexed uint128,indexed uint256,(uint8,uint256,uint256,address,bytes32,uint256,bool,uint256))',
+          handler: 'handleSettlementStrategyEnabled',
+        },
+        {
+          event: 'MarketUpdated(uint128,uint256,int256,uint256,int256,int256,int256,uint128)',
+          handler: 'handleMarketUpdated',
+        },
+        {
+          event: 'PermissionGranted(indexed uint128,indexed bytes32,indexed address,address)',
+          handler: 'handlePermissionGranted',
+        },
+        {
+          event: 'PermissionRevoked(indexed uint128,indexed bytes32,indexed address,address)',
+          handler: 'handlePermissionRevoked',
+        },
+        {
+          event: 'CollateralModified(indexed uint128,indexed uint128,int256,indexed address)',
+          handler: 'handleCollateralModified',
+        },
+        {
+          event:
+            'OrderCommitted(indexed uint128,indexed uint128,uint8,int128,uint256,uint256,uint256,uint256,uint256,indexed bytes32,address)',
+          handler: 'handleOrderCommitted',
+        },
+        {
+          event: 'InterestCharged(indexed uint128,uint256)',
+          handler: 'handleInterestCharged',
+        },
+      ],
+    },
+  });
 });
 
-manifest.push({
-  kind: 'ethereum/contract',
-  name: 'PerpsV3Legacy',
-  network: currentNetwork,
-  source: {
-    address: config.marketProxy.address,
-    abi: 'PerpsV3MarketProxyLegacy',
-    startBlock: config.marketProxy.startBlock,
-  },
-  mapping: {
-    kind: 'ethereum/events',
-    apiVersion: '0.0.6',
-    language: 'wasm/assemblyscript',
-    file: '../src/perps-v3.ts',
-    entities: ['Account', 'OrderSettled', 'DelegatedAccount'],
-    abis: [
-      {
-        name: 'PerpsV3MarketProxyLegacy',
-        file: '../abis/PerpsV3MarketProxyLegacy.json',
-      },
-    ],
-    eventHandlers: [
-      {
-        event: 'MarketUpdated(uint128,uint256,int256,uint256,int256,int256,int256)',
-        handler: 'handleMarketUpdated',
-      },
-    ],
-  },
+config.marketProxy.forEach((marketProxy, ind) => {
+  manifest.push({
+    kind: 'ethereum/contract',
+    name: `PerpsV3Legacy_${ind}`,
+    network: currentNetwork,
+    source: {
+      address: marketProxy.address,
+      abi: 'PerpsV3MarketProxyLegacy',
+      startBlock: marketProxy.startBlock,
+    },
+    mapping: {
+      kind: 'ethereum/events',
+      apiVersion: '0.0.6',
+      language: 'wasm/assemblyscript',
+      file: '../src/perps-v3.ts',
+      entities: ['Account', 'OrderSettled', 'DelegatedAccount'],
+      abis: [
+        {
+          name: 'PerpsV3MarketProxyLegacy',
+          file: '../abis/PerpsV3MarketProxyLegacy.json',
+        },
+      ],
+      eventHandlers: [
+        {
+          event: 'MarketUpdated(uint128,uint256,int256,uint256,int256,int256,int256)',
+          handler: 'handleMarketUpdated',
+        },
+      ],
+    },
+  });
 });
 
 module.exports = {


### PR DESCRIPTION
## Description
SNX redeployed everything on base sepolia so the contract address of perps market proxy needs to be updated.
deployment: [base-sepolia-perps-v3 0.0.10](https://subgraphs.alchemy.com/subgraphs/3903/versions/15804)

## Screenshots
<img width="1482" alt="截屏2024-04-06 16 57 48" src="https://github.com/Kwenta/kwenta-subgraph/assets/4819006/5c61b11f-c529-4486-b1b3-e5b08328240c">
