### PR TITLE
Add the aggregate stats for all markets to v3

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -582,5 +582,11 @@ export function updateAggregateStatEntities(
     aggStats.trades = aggStats.trades.plus(trades);
     aggStats.volume = aggStats.volume.plus(volume);
     aggStats.save();
+
+    // update the aggregate for all markets
+    let aggCumulativeStats = getOrCreateMarketAggregateStats(new BigInt(0), 'ALL', aggTimestamp, thisPeriod);
+    aggCumulativeStats.trades = aggCumulativeStats.trades.plus(trades);
+    aggCumulativeStats.volume = aggCumulativeStats.volume.plus(volume);
+    aggCumulativeStats.save();
   }
 }


### PR DESCRIPTION
## Description
Add aggregate market stats for all markets to perps V3, mirroring those in perps V2.

## Deployments
[base-sepolia live](https://subgraphs.alchemy.com/subgraphs/3903)
[base-mainnet 0.0.15](https://subgraphs.alchemy.com/subgraphs/3183/versions/16957)