### PR TITLE
fix: Removed the tracking code in the perps v3 aggregated stats

### DIFF
--- a/src/perps-v3.ts
+++ b/src/perps-v3.ts
@@ -239,15 +239,13 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     positionEntity.totalReducedNotional = ZERO;
     positionEntity.interestCharged = ZERO;
 
-    if (event.params.trackingCode.toString() == 'KWENTA') {
-      updateAggregateStatEntities(
-        positionEntity.marketId,
-        positionEntity.marketSymbol,
-        event.block.timestamp,
-        ONE,
-        volume,
-      );
-    }
+    updateAggregateStatEntities(
+      positionEntity.marketId,
+      positionEntity.marketSymbol,
+      event.block.timestamp,
+      ONE,
+      volume,
+    );
 
     statEntity.feesPaid = statEntity.feesPaid.plus(event.params.totalFees);
     statEntity.totalTrades = statEntity.totalTrades.plus(BigInt.fromI32(1));
@@ -313,15 +311,13 @@ export function handleOrderSettled(event: OrderSettledEvent): void {
     order.position = positionEntity.id;
     positionEntity.size = positionEntity.size.plus(event.params.sizeDelta);
 
-    if (event.params.trackingCode.toString() == 'KWENTA') {
-      updateAggregateStatEntities(
-        positionEntity.marketId,
-        positionEntity.marketSymbol,
-        event.block.timestamp,
-        ONE,
-        volume,
-      );
-    }
+    updateAggregateStatEntities(
+      positionEntity.marketId,
+      positionEntity.marketSymbol,
+      event.block.timestamp,
+      ONE,
+      volume,
+    );
 
     statEntity.feesPaid = statEntity.feesPaid.plus(event.params.totalFees).minus(event.params.accruedFunding);
 


### PR DESCRIPTION
After the tracking code update, we were unable to retrieve daily volumes using the previous tracking code. This PR resolves the issue by removing the tracking code during aggregated statistics updates.

snx-v3-base: v0.0.21 https://subgraphs.alchemy.com/subgraphs/3183/versions/32499
snx-v3-arb: v0.0.6 https://subgraphs.alchemy.com/subgraphs/7661/versions/32498

preview deployment: https://kwenta-private-92ka1a7nw-kwenta.vercel.app/market/?provider=snx_v3_arb&asset=sETH 